### PR TITLE
Input system refactor

### DIFF
--- a/lua/entities/base_glide/sv_input.lua
+++ b/lua/entities/base_glide/sv_input.lua
@@ -26,14 +26,14 @@ function ENT:GetInputBool( seatIndex, action )
 end
 
 do
-    -- Translate these boolean actions to float values
+    -- Translate these boolean actions to float values.
     local BOOL_TO_FLOAT = {
         ["accelerate"] = { "", "accelerate" },
         ["brake"] = { "", "brake" },
         ["steer"] = { "steer_left", "steer_right" },
         ["pitch"] = { "pitch_up", "pitch_down" },
         ["roll"] = { "roll_left", "roll_right" },
-        ["rudder"] = { "rudder_left", "rudder_right" },
+        ["yaw"] = { "yaw_left", "yaw_right" },
         ["throttle"] = { "throttle_down", "throttle_up" },
         ["lean_pitch"] = { "lean_back", "lean_forward" }
     }

--- a/lua/entities/base_glide_aircraft/init.lua
+++ b/lua/entities/base_glide_aircraft/init.lua
@@ -468,7 +468,7 @@ function ENT:TriggerInput( name, value )
         self:SetInputFloat( 1, "pitch", Clamp( value, -1, 1 ) )
 
     elseif name == "Yaw" then
-        self:SetInputFloat( 1, "rudder", Clamp( value, -1, 1 ) )
+        self:SetInputFloat( 1, "yaw", Clamp( value, -1, 1 ) )
 
     elseif name == "Roll" then
         self:SetInputFloat( 1, "roll", Clamp( value, -1, 1 ) )

--- a/lua/entities/base_glide_heli/init.lua
+++ b/lua/entities/base_glide_heli/init.lua
@@ -116,16 +116,16 @@ function ENT:OnPostThink( dt )
     if self.inputFlyMode == 2 then -- Glide.MOUSE_FLY_MODE.CAMERA
         self.inputPitch = ExpDecay( self.inputPitch, self:GetInputFloat( 1, "pitch" ), 6, dt )
         self.inputRoll = ExpDecay( self.inputRoll, self:GetInputFloat( 1, "roll" ), 6, dt )
-        self.inputYaw = ExpDecay( self.inputYaw, self:GetInputFloat( 1, "rudder" ), 6, dt )
+        self.inputYaw = ExpDecay( self.inputYaw, self:GetInputFloat( 1, "yaw" ), 6, dt )
 
     elseif self.inputFlyMode == 1 then -- Glide.MOUSE_FLY_MODE.DIRECT
         self.inputPitch = self:GetInputFloat( 1, "pitch" )
         self.inputRoll = self:GetInputFloat( 1, "roll" )
-        self.inputYaw = ExpDecay( self.inputYaw, self:GetInputFloat( 1, "rudder" ), 6, dt )
+        self.inputYaw = ExpDecay( self.inputYaw, self:GetInputFloat( 1, "yaw" ), 6, dt )
     else
         self.inputPitch = self:GetInputFloat( 1, "pitch" )
         self.inputRoll = self:GetInputFloat( 1, "roll" )
-        self.inputYaw = self:GetInputFloat( 1, "rudder" )
+        self.inputYaw = self:GetInputFloat( 1, "yaw" )
     end
 
     local power = self:GetPower()

--- a/lua/entities/base_glide_plane/init.lua
+++ b/lua/entities/base_glide_plane/init.lua
@@ -121,7 +121,7 @@ function ENT:OnPostThink( dt )
 
     self.inputPitch = ExpDecay( self.inputPitch, self:GetInputFloat( 1, "pitch" ), 10, dt )
     self.inputRoll = ExpDecay( self.inputRoll, self:GetInputFloat( 1, "roll" ), 10, dt )
-    self.inputYaw = ExpDecay( self.inputYaw, self:GetInputFloat( 1, "rudder" ), 10, dt )
+    self.inputYaw = ExpDecay( self.inputYaw, self:GetInputFloat( 1, "yaw" ), 10, dt )
 
     self:SetElevator( self.inputPitch )
     self:SetRudder( self.inputYaw )

--- a/lua/glide/client/camera.lua
+++ b/lua/glide/client/camera.lua
@@ -232,7 +232,7 @@ function Camera:Think()
         decay = 0
 
     elseif mode == CAMERA_TYPE.AIRCRAFT then
-        self.isUsingDirectMouse = Config.mouseFlyMode == MOUSE_FLY_MODE.DIRECT and self.seatIndex == 1 and not IsKeyDown( Config.binds.free_look )
+        self.isUsingDirectMouse = Config.mouseFlyMode == MOUSE_FLY_MODE.DIRECT and self.seatIndex == 1 and not IsKeyDown( Config.binds.aircraft_controls.free_look )
         self.allowRolling = Config.mouseFlyMode ~= MOUSE_FLY_MODE.AIM
 
         -- Make the camera angles smoothly point towards the vehicle's forward direction.

--- a/lua/glide/client/config.lua
+++ b/lua/glide/client/config.lua
@@ -422,26 +422,13 @@ function Config:OpenFrame()
 
     ----- Keyboard settings -----
 
-    local SEAT_SWITCH_KEYS = {
-        [KEY_1] = 1,
-        [KEY_2] = 2,
-        [KEY_3] = 3,
-        [KEY_4] = 4,
-        [KEY_5] = 5,
-        [KEY_6] = 6,
-        [KEY_7] = 7,
-        [KEY_8] = 8,
-        [KEY_9] = 9,
-        [KEY_0] = 10
-    }
-
     local CreateBinderButton = function( parent, text, actionId, defaultKey, callback )
         local binder = theme:CreateBinderButton( parent, text, defaultKey )
 
         function binder:OnChange( value )
             if self._ignoreChange then return end
 
-            if SEAT_SWITCH_KEYS[value] then
+            if Glide.SEAT_SWITCH_BUTTONS[value] then
                 self._ignoreChange = true
                 binder:SetValue( defaultKey )
                 self._ignoreChange = nil

--- a/lua/glide/client/config.lua
+++ b/lua/glide/client/config.lua
@@ -37,59 +37,27 @@ function Config:Reset()
     self.mouseShow = true
 
     -- Misc. settings
+    self.manualGearShifting = false
     self.autoHeadlightOn = true
     self.autoHeadlightOff = true
     self.headlightShadows = true
     self.enableTips = true
 end
 
---- Reset binds to their default keys.
+--- Reset binds to their default buttons.
 function Config:ResetBinds()
-    -- Action-key dictionary, aka. button binds
-    self.binds = {}
-    self.manualGearShifting = false
+    local binds = {}
 
-    -- General inputs
-    self:SetActionKey( "switch_weapon", KEY_R )
-    self:SetActionKey( "attack", KEY_SPACE )
-    self:SetActionKey( "attack_alt", MOUSE_LEFT )
+    -- Setup default action categories and buttons
+    for category, actions in pairs( Glide.InputCategories ) do
+        binds[category] = {}
 
-    -- Car inputs
-    self:SetActionKey( "steer_left", KEY_A )
-    self:SetActionKey( "steer_right", KEY_D )
-    self:SetActionKey( "accelerate", KEY_W )
-    self:SetActionKey( "brake", KEY_S )
-    self:SetActionKey( "handbrake", KEY_SPACE )
-    self:SetActionKey( "horn", KEY_R )
-    self:SetActionKey( "headlights", KEY_H )
-    self:SetActionKey( "reduce_throttle", KEY_LSHIFT )
+        for action, button in pairs( actions ) do
+            binds[category][action] = button
+        end
+    end
 
-    self:SetActionKey( "shift_up", KEY_F )
-    self:SetActionKey( "shift_down", KEY_G )
-    self:SetActionKey( "shift_neutral", KEY_N )
-
-    -- Airborne car/bike controls
-    self:SetActionKey( "lean_forward", KEY_UP )
-    self:SetActionKey( "lean_back", KEY_DOWN )
-
-    -- Aircraft inputs
-    self:SetActionKey( "countermeasures", KEY_F )
-    self:SetActionKey( "free_look", KEY_LALT )
-
-    self:SetActionKey( "landing_gear", KEY_G )
-    self:SetActionKey( "pitch_up", KEY_DOWN )
-    self:SetActionKey( "pitch_down", KEY_UP )
-    self:SetActionKey( "roll_left", KEY_LEFT )
-    self:SetActionKey( "roll_right", KEY_RIGHT )
-    self:SetActionKey( "rudder_left", KEY_A )
-    self:SetActionKey( "rudder_right", KEY_D )
-    self:SetActionKey( "throttle_up", KEY_W )
-    self:SetActionKey( "throttle_down", KEY_S )
-end
-
---- Set which key triggers an action.
-function Config:SetActionKey( action, button )
-    self.binds[action] = button
+    self.binds = binds
 end
 
 --- Save settings to disk.
@@ -139,14 +107,14 @@ function Config:Save( immediate )
         mouseShow = self.mouseShow,
 
         -- Misc. settings
+        manualGearShifting = self.manualGearShifting,
         autoHeadlightOn = self.autoHeadlightOn,
         autoHeadlightOff = self.autoHeadlightOff,
         headlightShadows = self.headlightShadows,
         enableTips = self.enableTips,
 
-        -- Action-key dictionary
-        binds = self.binds,
-        manualGearShifting = self.manualGearShifting
+        -- Category-action-button dictionary
+        binds = self.binds
     }, true )
 
     Glide.SaveDataFile( "glide.json", data )
@@ -198,19 +166,23 @@ function Config:Load()
     LoadBool( "mouseShow", true )
 
     -- Misc. settings
+    LoadBool( "manualGearShifting", false )
     LoadBool( "autoHeadlightOn", true )
     LoadBool( "autoHeadlightOff", false )
     LoadBool( "headlightShadows", true )
     LoadBool( "enableTips", true )
 
-    -- Action-key dictionary
-    LoadBool( "manualGearShifting", false )
-
-    local binds = self.binds
+    -- Category-action-button dictionary
     local loadedBinds = type( data.binds ) == "table" and data.binds or {}
 
-    for action, button in pairs( binds ) do
-        SetNumber( binds, action, loadedBinds[action], KEY_NONE, BUTTON_CODE_LAST, button )
+    for category, actions in pairs( self.binds ) do
+        for action, button in pairs( actions ) do
+            local loadedCategory = loadedBinds[category]
+
+            if type( loadedCategory ) == "table" then
+                SetNumber( actions, action, loadedCategory[action], KEY_NONE, BUTTON_CODE_LAST, button )
+            end
+        end
     end
 end
 
@@ -483,29 +455,41 @@ function Config:OpenFrame()
     end
 
     local panelKeyboard = frame:AddTab( "icon16/keyboard.png", L"settings.input" )
-
     local binds = self.binds
 
-    local function OnChangeBind( action, key )
-        binds[action] = key
+    local generalBinds = binds["general_controls"]
+
+    local function OnChangeGeneralBind( action, key )
+        generalBinds[action] = key
         self:Save()
         self:TransmitInputSettings()
     end
 
     theme:CreateHeader( panelKeyboard, L"input.general_controls" )
-    CreateBinderButton( panelKeyboard, L"input.switch_weapon", "switch_weapon", binds.switch_weapon, OnChangeBind )
-    CreateBinderButton( panelKeyboard, L"input.attack", "attack", binds.attack, OnChangeBind )
-    CreateBinderButton( panelKeyboard, L"input.attack_alt", "attack_alt", binds.attack_alt, OnChangeBind )
+    CreateBinderButton( panelKeyboard, L"input.switch_weapon", "switch_weapon", generalBinds.switch_weapon, OnChangeGeneralBind )
 
-    theme:CreateHeader( panelKeyboard, L"input.car_controls" )
-    CreateBinderButton( panelKeyboard, L"input.steer_left", "steer_left", binds.steer_left, OnChangeBind )
-    CreateBinderButton( panelKeyboard, L"input.steer_right", "steer_right", binds.steer_right, OnChangeBind )
-    CreateBinderButton( panelKeyboard, L"input.accelerate", "accelerate", binds.accelerate, OnChangeBind )
-    CreateBinderButton( panelKeyboard, L"input.brake", "brake", binds.brake, OnChangeBind )
-    CreateBinderButton( panelKeyboard, L"input.handbrake", "handbrake", binds.handbrake, OnChangeBind )
-    CreateBinderButton( panelKeyboard, L"input.horn", "horn", binds.horn, OnChangeBind )
-    CreateBinderButton( panelKeyboard, L"input.headlights", "headlights", binds.headlights, OnChangeBind )
-    CreateBinderButton( panelKeyboard, L"input.reduce_throttle", "reduce_throttle", binds.reduce_throttle, OnChangeBind )
+    local landBinds = binds["land_controls"]
+
+    local function OnChangeLandBind( action, key )
+        landBinds[action] = key
+        self:Save()
+        self:TransmitInputSettings()
+    end
+
+    theme:CreateHeader( panelKeyboard, L"input.land_controls" )
+    CreateBinderButton( panelKeyboard, L"input.attack", "attack", landBinds.attack, OnChangeLandBind )
+
+    CreateBinderButton( panelKeyboard, L"input.steer_left", "steer_left", landBinds.steer_left, OnChangeLandBind )
+    CreateBinderButton( panelKeyboard, L"input.steer_right", "steer_right", landBinds.steer_right, OnChangeLandBind )
+    CreateBinderButton( panelKeyboard, L"input.accelerate", "accelerate", landBinds.accelerate, OnChangeLandBind )
+    CreateBinderButton( panelKeyboard, L"input.brake", "brake", landBinds.brake, OnChangeLandBind )
+    CreateBinderButton( panelKeyboard, L"input.handbrake", "handbrake", landBinds.handbrake, OnChangeLandBind )
+
+    CreateBinderButton( panelKeyboard, L"input.horn", "horn", landBinds.horn, OnChangeLandBind )
+    CreateBinderButton( panelKeyboard, L"input.headlights", "headlights", landBinds.headlights, OnChangeLandBind )
+    CreateBinderButton( panelKeyboard, L"input.reduce_throttle", "reduce_throttle", landBinds.reduce_throttle, OnChangeLandBind )
+    CreateBinderButton( panelKeyboard, L"input.lean_forward", "lean_forward", landBinds.lean_forward, OnChangeLandBind )
+    CreateBinderButton( panelKeyboard, L"input.lean_back", "lean_back", landBinds.lean_back, OnChangeLandBind )
 
     theme:CreateHeader( panelKeyboard, L"input.manual_shift" )
     theme:CreateToggleButton( panelKeyboard, L"input.manual_shift", self.manualGearShifting, function( value )
@@ -514,26 +498,34 @@ function Config:OpenFrame()
         self:TransmitInputSettings()
     end )
 
-    CreateBinderButton( panelKeyboard, L"input.shift_up", "shift_up", binds.shift_up, OnChangeBind )
-    CreateBinderButton( panelKeyboard, L"input.shift_down", "shift_down", binds.shift_down, OnChangeBind )
-    CreateBinderButton( panelKeyboard, L"input.shift_neutral", "shift_neutral", binds.shift_neutral, OnChangeBind )
+    CreateBinderButton( panelKeyboard, L"input.shift_up", "shift_up", landBinds.shift_up, OnChangeLandBind )
+    CreateBinderButton( panelKeyboard, L"input.shift_down", "shift_down", landBinds.shift_down, OnChangeLandBind )
+    CreateBinderButton( panelKeyboard, L"input.shift_neutral", "shift_neutral", landBinds.shift_neutral, OnChangeLandBind )
 
-    theme:CreateHeader( panelKeyboard, L"input.air_car_controls" )
-    CreateBinderButton( panelKeyboard, L"input.lean_forward", "lean_forward", binds.lean_forward, OnChangeBind )
-    CreateBinderButton( panelKeyboard, L"input.lean_back", "lean_back", binds.lean_back, OnChangeBind )
+    local airBinds = binds["aircraft_controls"]
+
+    local function OnChangeAirBind( action, key )
+        airBinds[action] = key
+        self:Save()
+        self:TransmitInputSettings()
+    end
 
     theme:CreateHeader( panelKeyboard, L"input.aircraft_controls" )
-    CreateBinderButton( panelKeyboard, L"input.countermeasures", "countermeasures", binds.countermeasures, OnChangeBind )
-    CreateBinderButton( panelKeyboard, L"input.free_look", "free_look", binds.free_look, OnChangeBind )
-    CreateBinderButton( panelKeyboard, L"input.landing_gear", "landing_gear", binds.landing_gear, OnChangeBind )
-    CreateBinderButton( panelKeyboard, L"input.pitch_up", "pitch_up", binds.pitch_up, OnChangeBind )
-    CreateBinderButton( panelKeyboard, L"input.pitch_down", "pitch_down", binds.pitch_down, OnChangeBind )
-    CreateBinderButton( panelKeyboard, L"input.roll_left", "roll_left", binds.roll_left, OnChangeBind )
-    CreateBinderButton( panelKeyboard, L"input.roll_right", "roll_right", binds.roll_right, OnChangeBind )
-    CreateBinderButton( panelKeyboard, L"input.rudder_left", "rudder_left", binds.rudder_left, OnChangeBind )
-    CreateBinderButton( panelKeyboard, L"input.rudder_right", "rudder_right", binds.rudder_right, OnChangeBind )
-    CreateBinderButton( panelKeyboard, L"input.throttle_up", "throttle_up", binds.throttle_up, OnChangeBind )
-    CreateBinderButton( panelKeyboard, L"input.throttle_down", "throttle_down", binds.throttle_down, OnChangeBind )
+    CreateBinderButton( panelKeyboard, L"input.attack", "attack", airBinds.attack, OnChangeAirBind )
+    CreateBinderButton( panelKeyboard, L"input.attack_alt", "attack_alt", airBinds.attack_alt, OnChangeAirBind )
+
+    CreateBinderButton( panelKeyboard, L"input.free_look", "free_look", airBinds.free_look, OnChangeAirBind )
+    CreateBinderButton( panelKeyboard, L"input.landing_gear", "landing_gear", airBinds.landing_gear, OnChangeAirBind )
+    CreateBinderButton( panelKeyboard, L"input.countermeasures", "countermeasures", airBinds.countermeasures, OnChangeAirBind )
+
+    CreateBinderButton( panelKeyboard, L"input.pitch_up", "pitch_up", airBinds.pitch_up, OnChangeAirBind )
+    CreateBinderButton( panelKeyboard, L"input.pitch_down", "pitch_down", airBinds.pitch_down, OnChangeAirBind )
+    CreateBinderButton( panelKeyboard, L"input.yaw_left", "yaw_left", airBinds.yaw_left, OnChangeAirBind )
+    CreateBinderButton( panelKeyboard, L"input.yaw_right", "yaw_right", airBinds.yaw_right, OnChangeAirBind )
+    CreateBinderButton( panelKeyboard, L"input.roll_left", "roll_left", airBinds.roll_left, OnChangeAirBind )
+    CreateBinderButton( panelKeyboard, L"input.roll_right", "roll_right", airBinds.roll_right, OnChangeAirBind )
+    CreateBinderButton( panelKeyboard, L"input.throttle_up", "throttle_up", airBinds.throttle_up, OnChangeAirBind )
+    CreateBinderButton( panelKeyboard, L"input.throttle_down", "throttle_down", airBinds.throttle_down, OnChangeAirBind )
 
     ----- Audio settings -----
 

--- a/lua/glide/client/mouse_input.lua
+++ b/lua/glide/client/mouse_input.lua
@@ -96,7 +96,7 @@ local Abs = math.abs
 local Approach = math.Approach
 
 function MouseInput:Think()
-    self.freeLook = input.IsKeyDown( Config.binds.free_look )
+    self.freeLook = input.IsKeyDown( Config.binds.aircraft_controls.free_look )
 
     if self.freeLook then
         self:Reset()

--- a/lua/glide/client/network.lua
+++ b/lua/glide/client/network.lua
@@ -18,7 +18,7 @@ commands[Glide.CMD_INCOMING_DANGER] = function()
         Glide.LockOnHandler:OnIncomingMissile( net.ReadUInt( 32 ) )
         Glide.ShowKeyTip(
             "#glide.notify.tip.countermeasures",
-            Glide.Config.binds["countermeasures"],
+            Glide.Config.binds["aircraft_controls"]["countermeasures"],
             "materials/glide/icons/rocket.png"
         )
     end

--- a/lua/glide/client/notify.lua
+++ b/lua/glide/client/notify.lua
@@ -146,7 +146,7 @@ hook.Add( "Glide_OnLocalEnterVehicle", "Glide.ShowVehicleTips", function( _, sea
         if not IsValid( veh ) then return end
 
         if Glide.HasBaseClass( veh, "base_glide_car" ) then
-            Glide.ShowKeyTip( "#glide.notify.tip.headlights", Glide.Config.binds["headlights"] )
+            Glide.ShowKeyTip( "#glide.notify.tip.headlights", Glide.Config.binds["land_controls"]["headlights"] )
 
         elseif Glide.HasBaseClass( veh, "base_glide_heli" ) and Glide.Config.mouseFlyMode == Glide.MOUSE_FLY_MODE.AIM then
             Glide.ShowTip( "#glide.notify.tip.heli_controls", "materials/glide/icons/helicopter.png" )

--- a/lua/glide/sh_input.lua
+++ b/lua/glide/sh_input.lua
@@ -53,3 +53,28 @@ InputCategories["aircraft_controls"] = {
     ["throttle_up"] = KEY_W,
     ["throttle_down"] = KEY_S
 }
+
+-- Allow some actions to trigger others
+Glide.ACTION_ALIASES = {
+    ["attack_alt"] = "attack"
+}
+
+-- Replace actions while using the mouse `Point-to-aim` mode.
+Glide.MOUSE_AIM_ACTION_OVERRIDE = {
+    ["yaw_left"] = "roll_left",
+    ["yaw_right"] = "roll_right"
+}
+
+-- Keys reserved for seat switching
+Glide.SEAT_SWITCH_BUTTONS = {
+    [KEY_1] = 1,
+    [KEY_2] = 2,
+    [KEY_3] = 3,
+    [KEY_4] = 4,
+    [KEY_5] = 5,
+    [KEY_6] = 6,
+    [KEY_7] = 7,
+    [KEY_8] = 8,
+    [KEY_9] = 9,
+    [KEY_0] = 10
+}

--- a/lua/glide/sh_input.lua
+++ b/lua/glide/sh_input.lua
@@ -1,0 +1,55 @@
+--[[
+    Categorize and enumerate input actions.
+
+    Each category contains a key-value pairs of
+    action names and the default key that triggers them.
+]]
+
+local InputCategories = Glide.InputCategories or {}
+
+Glide.InputCategories = InputCategories
+
+-- Inputs that apply to all vehicle types
+InputCategories["general_controls"] = {
+    ["switch_weapon"] = KEY_R
+}
+
+-- Inputs that only apply to land vehicle types
+InputCategories["land_controls"] = {
+    ["attack"] = MOUSE_LEFT,
+
+    ["steer_left"] = KEY_A,
+    ["steer_right"] = KEY_D,
+    ["accelerate"] = KEY_W,
+    ["brake"] = KEY_S,
+    ["handbrake"] = KEY_SPACE,
+
+    ["horn"] = KEY_R,
+    ["headlights"] = KEY_H,
+    ["reduce_throttle"] = KEY_LSHIFT,
+    ["lean_forward"] = KEY_UP,
+    ["lean_back"] = KEY_DOWN,
+
+    ["shift_up"] = KEY_F,
+    ["shift_down"] = KEY_G,
+    ["shift_neutral"] = KEY_N
+}
+
+-- Inputs that only apply to aicraft vehicle types
+InputCategories["aircraft_controls"] = {
+    ["attack"] = MOUSE_LEFT,
+    ["attack_alt"] = KEY_SPACE,
+
+    ["free_look"] = KEY_LALT,
+    ["landing_gear"] = KEY_G,
+    ["countermeasures"] = KEY_F,
+
+    ["pitch_up"] = KEY_DOWN,
+    ["pitch_down"] = KEY_UP,
+    ["yaw_left"] = KEY_A,
+    ["yaw_right"] = KEY_D,
+    ["roll_left"] = KEY_LEFT,
+    ["roll_right"] = KEY_RIGHT,
+    ["throttle_up"] = KEY_W,
+    ["throttle_down"] = KEY_S
+}

--- a/resource/localization/en/glide_vehicles.properties
+++ b/resource/localization/en/glide_vehicles.properties
@@ -48,7 +48,7 @@ glide.input.switch_weapon=Switch weapon
 glide.input.attack=Fire weapon
 glide.input.attack_alt=Fire weapon (Alternate)
 
-glide.input.car_controls=Car controls
+glide.input.land_controls=Land vehicle controls
 glide.input.steer_left=Steer left
 glide.input.steer_right=Steer right
 glide.input.accelerate=Accelerate
@@ -63,7 +63,6 @@ glide.input.shift_up=Shift gear up
 glide.input.shift_down=Shift gear down
 glide.input.shift_neutral=Shift gear to neutral
 
-glide.input.air_car_controls=Airborne car/motorcycle controls
 glide.input.lean_forward=Lean forward
 glide.input.lean_back=Lean back
 
@@ -73,10 +72,10 @@ glide.input.free_look=Free look (Flying with mouse only)
 glide.input.landing_gear=Landing gear
 glide.input.pitch_up=Pitch up
 glide.input.pitch_down=Pitch down
+glide.input.yaw_left=Yaw left
+glide.input.yaw_right=Yaw right
 glide.input.roll_left=Roll left
 glide.input.roll_right=Roll right
-glide.input.rudder_left=Yaw left
-glide.input.rudder_right=Yaw right
 glide.input.throttle_up=Increase throttle
 glide.input.throttle_down=Decrease throttle
 

--- a/resource/localization/pt-br/glide_vehicles.properties
+++ b/resource/localization/pt-br/glide_vehicles.properties
@@ -48,7 +48,7 @@ glide.input.switch_weapon=Mudar arma
 glide.input.attack=Atirar arma
 glide.input.attack_alt=Atirar arma (Alternativo)
 
-glide.input.car_controls=Controles de carro
+glide.input.land_controls=Controles de veículos terrestres
 glide.input.steer_left=Virar à esquerda
 glide.input.steer_right=Virar à direita
 glide.input.accelerate=Acelerar
@@ -63,7 +63,6 @@ glide.input.shift_up=Marcha para cima
 glide.input.shift_down=Marcha para baixo
 glide.input.shift_neutral=Marcha para neutro
 
-glide.input.air_car_controls=Controles de carro/moto no ar
 glide.input.lean_forward=Inclinar para frente
 glide.input.lean_back=Inclinar para trás
 
@@ -73,10 +72,10 @@ glide.input.free_look=Olhar livremente (Somente ao voar com o mouse)
 glide.input.landing_gear=Trem de pouso
 glide.input.pitch_up=Inclinar para cima
 glide.input.pitch_down=Inclinar para baixo
+glide.input.yaw_left=Leme à esquerda
+glide.input.yaw_right=Leme à direita
 glide.input.roll_left=Rolar à esquerda
 glide.input.roll_right=Rolar à direita
-glide.input.rudder_left=Leme à esquerda
-glide.input.rudder_right=Leme à direita
 glide.input.throttle_up=Aumentar acelerador
 glide.input.throttle_down=Diminuir acelerador
 


### PR DESCRIPTION
The input system now separates actions into categories, which are used to only enable buttons per vehicle type.

- Allows tanks to use `KEY_SPACE` for handbrake without conflicting with the `attack` action from aircraft
- Allows different vehicle types to have separate `attack` actions
- Renamed aircraft input actions related to `rudder` to `yaw`