### PR TITLE
Add power distribution to cars

### DIFF
--- a/lua/entities/base_glide/sv_wheels.lua
+++ b/lua/entities/base_glide/sv_wheels.lua
@@ -14,12 +14,12 @@ function ENT:WheelInit()
 
         -- Static friction
         maxSlip = 20,
-        slipForce = 70,
+        slipForce = 80,
 
         -- Dynamic friction
-        extremumValue = 5.0,
+        extremumValue = 4.0,
         asymptoteSlip = 0.5,
-        asymptoteValue = 2.0
+        asymptoteValue = 1.2
     }
 end
 

--- a/lua/entities/base_glide_car/init.lua
+++ b/lua/entities/base_glide_car/init.lua
@@ -31,7 +31,6 @@ function ENT:OnPostInitialize()
     self:SetSteering( 0 )
     self:SetEngineRPM( 0 )
     self:SetEngineThrottle( 0 )
-    self:SetPowerDistribution( -0.8 )
 
     self:SetTireSmokeColor( Vector( 0.6, 0.6, 0.6 ) )
     self:SetWheelRadius( 15 )
@@ -67,15 +66,16 @@ function ENT:OnPostInitialize()
     self:SetMinRPM( 2000 )
     self:SetMaxRPM( 20000 )
 
-    self:SetMinRPMTorque( 1100 )
-    self:SetMaxRPMTorque( 1300 )
+    self:SetMinRPMTorque( 1200 )
+    self:SetMaxRPMTorque( 1500 )
     self:SetDifferentialRatio( 1.9 )
     self:SetTransmissionEfficiency( 0.8 )
+    self:SetPowerDistribution( -0.9 )
 
     -- Steering parameters
     self:SetMaxSteerAngle( 35 )
     self:SetSteerConeChangeRate( 8 )
-    self:SetSteerConeMaxSpeed( 1500 )
+    self:SetSteerConeMaxSpeed( 1800 )
     self:SetSteerConeMaxAngle( 0.25 )
 
     -- Update wheel parameters next tick

--- a/lua/entities/base_glide_car/init.lua
+++ b/lua/entities/base_glide_car/init.lua
@@ -392,7 +392,7 @@ function ENT:OnPostThink( dt )
 
     local phys = self:GetPhysicsObject()
 
-    if not self.areDriveWheelsGrounded and IsValid( phys ) then
+    if self.groundedCount < 1 and IsValid( phys ) then
         if self.totalSpeed > 200 then
             self:UpdateAirControls( phys, dt )
         else
@@ -493,7 +493,7 @@ function ENT:CreateWheel( offset, params )
 end
 
 local availableBrake, availableTorque, steerAngle, angVelMult
-local isGrounded, rpm, totalRPM, totalSideSlip, totalForwardSlip
+local groundedCount, rpm, totalRPM, totalSideSlip, totalForwardSlip
 
 --- Implement this base class function.
 function ENT:WheelThink( dt )
@@ -506,7 +506,7 @@ function ENT:WheelThink( dt )
     steerAngle = self.steerAngle
     angVelMult = self.driveWheelsAngVelMult
 
-    isGrounded, totalRPM, totalSideSlip, totalForwardSlip = false, 0, 0, 0
+    groundedCount, totalRPM, totalSideSlip, totalForwardSlip = 0, 0, 0, 0
 
     for _, w in ipairs( self.wheels ) do
         w:Update( self, steerAngle, isAsleep, dt )
@@ -525,17 +525,17 @@ function ENT:WheelThink( dt )
             if rpm > maxRPM then
                 w:SetRPM( maxRPM )
             end
-
-            if w.isOnGround then
-                isGrounded = true
-            end
         else
             w.brake = self.burnout * 0.5
+        end
+
+        if w.isOnGround then
+            groundedCount = groundedCount + 1
         end
     end
 
     self.avgPoweredRPM = totalRPM / self.poweredCount
-    self.areDriveWheelsGrounded = isGrounded
+    self.groundedCount = groundedCount
     self.avgSideSlip = totalSideSlip / self.wheelCount
     self.avgForwardSlip = totalForwardSlip / self.wheelCount
 end

--- a/lua/entities/base_glide_car/init.lua
+++ b/lua/entities/base_glide_car/init.lua
@@ -504,7 +504,7 @@ function ENT:CreateWheel( offset, params )
     end
 
     -- Update power distribution next tick
-    wheel.powerDistribution = 0
+    wheel.distributionFactor = 0
     self.shouldUpdatePowerDistribution = true
 
     return wheel
@@ -534,9 +534,9 @@ function ENT:WheelThink( dt )
         totalForwardSlip = totalForwardSlip + w:GetForwardSlip()
 
         rpm = w:GetRPM()
-        avgRPM = avgRPM + rpm * w.powerDistribution
+        avgRPM = avgRPM + rpm * w.distributionFactor
 
-        w.torque = w.powerDistribution * ( w.isFrontWheel and frontTorque or rearTorque )
+        w.torque = w.distributionFactor * ( w.isFrontWheel and frontTorque or rearTorque )
         w.brake = w.isFrontWheel and frontBrake or rearBrake
         w.angularVelocity = w.angularVelocity * ( w.isFrontWheel and frontVelMult or rearVelMult )
 

--- a/lua/entities/base_glide_car/shared.lua
+++ b/lua/entities/base_glide_car/shared.lua
@@ -92,6 +92,7 @@ function ENT:SetupDataTables()
     AddFloatVar( "MaxRPMTorque", 10, 10000, "#glide.editvar.engine" )
     AddFloatVar( "DifferentialRatio", 0.5, 5, "#glide.editvar.engine" )
     AddFloatVar( "TransmissionEfficiency", 0.3, 1, "#glide.editvar.engine" )
+    AddFloatVar( "PowerDistribution", -1, 1, "#glide.editvar.engine" )
 
     -- Make wheel parameters available as network variables too
     AddFloatVar( "WheelRadius", 10, 40, Either( self.AllowEditWheelRadius, "#glide.editvar.wheels", nil ) )
@@ -112,6 +113,9 @@ function ENT:SetupDataTables()
     if SERVER then
         -- Callback used to change the wheel radius
         self:NetworkVarNotify( "WheelRadius", self.OnWheelRadiusChange )
+
+        -- Callback used to update the power distribution among wheels
+        self:NetworkVarNotify( "PowerDistribution", self.OnPowerDistributionChange )
     end
 
     if CLIENT then

--- a/lua/entities/base_glide_car/shared.lua
+++ b/lua/entities/base_glide_car/shared.lua
@@ -205,7 +205,7 @@ if SERVER then
     ENT.LightBodygroups = {}
 
     -- How much force to apply when trying to turn while doing a burnout?
-    ENT.BurnoutForce = 60
+    ENT.BurnoutForce = 45
 
     -- How much force to apply when the driver tries to unflip the vehicle?
     ENT.UnflipForce = 3
@@ -230,11 +230,11 @@ if SERVER then
             [-1] = 2.9, -- Reverse
             [0] = 0, -- Neutral (this number has no effect)
             [1] = 2.8,
-            [2] = 1.78,
-            [3] = 1.3,
-            [4] = 1,
-            [5] = 0.8,
-            [6] = 0.7
+            [2] = 1.7,
+            [3] = 1.2,
+            [4] = 0.9,
+            [5] = 0.75,
+            [6] = 0.68
         }
     end
 

--- a/lua/entities/base_glide_car/shared.lua
+++ b/lua/entities/base_glide_car/shared.lua
@@ -16,11 +16,8 @@ ENT.SeatPassengerAnim = "sit"
 -- Decrease default max. chassis health
 ENT.MaxChassisHealth = 900
 
--- Should we allow editing the wheel radius?
-ENT.AllowEditWheelRadius = true
-
--- Should we allow editing the suspension length?
-ENT.AllowEditSuspensionLen = true
+-- Should we prevent players from editing these NW variables?
+ENT.UneditableNWVars = {}
 
 DEFINE_BASECLASS( "base_glide" )
 
@@ -54,12 +51,13 @@ function ENT:SetupDataTables()
     self:NetworkVar( "Vector", "TireSmokeColor", { KeyName = "TireSmokeColor", Edit = { type = "VectorColor", order = 0, category = "#glide.editvar.wheels" } } )
 
     local order = 0
+    local uneditable = self.UneditableNWVars
 
     -- We add a bunch of floats here so, this utility function helps.
     local function AddFloatVar( key, min, max, category )
         order = order + 1
 
-        local editData = Either( category == nil, nil, {
+        local editData = Either( uneditable[key] == true or category == nil, nil, {
             KeyName = key,
             Edit = { type = "Float", order = order, min = min, max = max, category = category }
         } )
@@ -95,11 +93,11 @@ function ENT:SetupDataTables()
     AddFloatVar( "PowerDistribution", -1, 1, "#glide.editvar.engine" )
 
     -- Make wheel parameters available as network variables too
-    AddFloatVar( "WheelRadius", 10, 40, Either( self.AllowEditWheelRadius, "#glide.editvar.wheels", nil ) )
+    AddFloatVar( "WheelRadius", 10, 40, "#glide.editvar.wheels" )
     AddFloatVar( "WheelInertia", 1, 100, "#glide.editvar.wheels" )
     AddFloatVar( "BrakePower", 500, 5000, "#glide.editvar.wheels" )
 
-    AddFloatVar( "SuspensionLength", 5, 50, Either( self.AllowEditSuspensionLen, "#glide.editvar.suspension", nil ) )
+    AddFloatVar( "SuspensionLength", 5, 50, "#glide.editvar.suspension" )
     AddFloatVar( "SpringStrength", 100, 5000, "#glide.editvar.suspension" )
     AddFloatVar( "SpringDamper", 100, 10000, "#glide.editvar.suspension" )
 

--- a/lua/entities/base_glide_car/sv_engine.lua
+++ b/lua/entities/base_glide_car/sv_engine.lua
@@ -18,8 +18,9 @@ function ENT:EngineInit()
     self.reducedThrottle = false
 
     -- Wheel control variables
+    self.groundedCount = 0
+
     self.poweredCount = 0
-    self.areDriveWheelsGrounded = false
     self.driveWheelsAngVelMult = 1
     self.burnout = 0
 
@@ -135,7 +136,7 @@ function ENT:AutoGearSwitch( throttle )
     end
 
     if self.forwardSpeed < 0 and throttle < 0.1 then return end
-    if not self.areDriveWheelsGrounded then return end
+    if self.groundedCount < self.wheelCount then return end
     if Abs( self.avgForwardSlip ) > 1 then return end
 
     local minRPM, maxRPM = self:GetMinRPM(), self:GetMaxRPM()
@@ -188,7 +189,7 @@ function ENT:EngineClutch( dt )
     local absForwardSpeed = Abs( self.forwardSpeed )
 
     -- Are we airborne while going fast?
-    if not self.areDriveWheelsGrounded and absForwardSpeed > 30 then
+    if self.groundedCount < 1 and absForwardSpeed > 30 then
         return 1
     end
 
@@ -335,7 +336,7 @@ function ENT:EngineThink( dt )
 
         rpm = maxRPM
 
-        if gear ~= self.maxGear or not self.areDriveWheelsGrounded then
+        if gear ~= self.maxGear or self.groundedCount < self.wheelCount then
             isRedlining = true
         end
     end

--- a/lua/entities/base_glide_car/sv_engine.lua
+++ b/lua/entities/base_glide_car/sv_engine.lua
@@ -81,7 +81,7 @@ function ENT:UpdatePowerDistribution()
     rearDistribution = rearDistribution / rearCount
 
     for _, w in ipairs( self.wheels ) do
-        w.powerDistribution = w.isFrontWheel and frontDistribution or rearDistribution
+        w.distributionFactor = w.isFrontWheel and frontDistribution or rearDistribution
     end
 end
 
@@ -297,6 +297,9 @@ function ENT:EngineThink( dt )
 
         local frontBurnout = self:GetPowerDistribution() > 0
         local dir = frontBurnout and self:GetRight() or -self:GetRight()
+
+        self.frontBrake = frontBurnout and 1 or 0
+        self.rearBrake = frontBurnout and 0 or 1
 
         for _, w in ipairs( self.wheels ) do
             if w.isFrontWheel == frontBurnout then

--- a/lua/entities/base_glide_motorcycle/init.lua
+++ b/lua/entities/base_glide_motorcycle/init.lua
@@ -116,7 +116,8 @@ function ENT:UpdateSteering( dt )
         self.forwardSpeed > -100
     then
         self.reverseInput = 1 - Clamp( self.forwardSpeed / -100, 0, 1 )
-        self.brake = 0
+        self.frontBrake = 0
+        self.rearBrake = 0
         self.clutch = 1
         self:SetIsBraking( false )
     else
@@ -154,7 +155,7 @@ function ENT:OnSimulatePhysics( phys, _, outLin, outAng )
         local strength = 1 - Clamp( Abs( angles[1] ) / self.WheelieMaxAng, 0, 1 )
 
         strength = strength * Clamp( self.totalSpeed / 200, 0, 1 )
-        strength = strength * ( 1 - self.brake )
+        strength = strength * Clamp( 1 - self.frontBrake - self.rearBrake, 0, 1 )
 
         -- Drag
         outAng[2] = outAng[2] + angVel[2] * mass * self.WheelieDrag * strength

--- a/lua/entities/base_glide_motorcycle/init.lua
+++ b/lua/entities/base_glide_motorcycle/init.lua
@@ -91,13 +91,14 @@ local ExpDecay = Glide.ExpDecay
 function ENT:UpdateSteering( dt )
     BaseClass.UpdateSteering( self, dt )
 
+    local isAnyWheelGrounded = self.groundedCount > 0
     local invSpeedOverFactor = 1 - Clamp( self.totalSpeed / self:GetSteerConeMaxSpeed(), 0, 1 )
     local inputSteer = Clamp( self:GetInputFloat( 1, "steer" ), -1, 1 )
     local sideSlip = Clamp( self.avgSideSlip, -1, 1 )
 
     local tilt = Clamp( sideSlip * -2, -0.5, 0.5 )
 
-    if self.areDriveWheelsGrounded then
+    if isAnyWheelGrounded then
         tilt = tilt + inputSteer * Clamp( self.forwardSpeed / 300, 0, 1 )
 
         if self.totalSpeed < 20 then
@@ -105,14 +106,14 @@ function ENT:UpdateSteering( dt )
         end
     end
 
-    self.steerTilt = ExpDecay( self.steerTilt, tilt, 6 + invSpeedOverFactor * 4, dt )
+    self.steerTilt = ExpDecay( self.steerTilt, tilt, 6 + invSpeedOverFactor * 3, dt )
 
     if
+        isAnyWheelGrounded and
         self:GetInputFloat( 1, "brake" ) > 0 and
         self:GetInputFloat( 1, "accelerate" ) < 0.1 and
         self.forwardSpeed < 10 and
-        self.forwardSpeed > -100 and
-        self.areDriveWheelsGrounded
+        self.forwardSpeed > -100
     then
         self.reverseInput = 1 - Clamp( self.forwardSpeed / -100, 0, 1 )
         self.brake = 0
@@ -132,11 +133,12 @@ local WORLD_UP = Vector( 0, 0, 1 )
 function ENT:OnSimulatePhysics( phys, _, outLin, outAng )
     if not self.stayUpright then return end
 
+    local isAnyWheelGrounded = self.groundedCount > 0
     local angVel = phys:GetAngleVelocity()
     local mass = phys:GetMass()
 
     -- Apply an extra yaw angular drag
-    if self.areDriveWheelsGrounded then
+    if isAnyWheelGrounded then
         outAng[3] = outAng[3] + angVel[3] * mass * self.YawDrag
     else
         self.steerTilt = 0
@@ -148,7 +150,7 @@ function ENT:OnSimulatePhysics( phys, _, outLin, outAng )
     -- Wheelie
     local leanBack = self:GetInputBool( 1, "lean_back" )
 
-    if leanBack and self.areDriveWheelsGrounded then
+    if leanBack and isAnyWheelGrounded then
         local strength = 1 - Clamp( Abs( angles[1] ) / self.WheelieMaxAng, 0, 1 )
 
         strength = strength * Clamp( self.totalSpeed / 200, 0, 1 )
@@ -173,9 +175,8 @@ function ENT:OnSimulatePhysics( phys, _, outLin, outAng )
     local dot = WORLD_UP:Dot( rt )
     dot = angles[3] > -90 and angles[3] < 90 and dot or -dot
 
-    local isGrounded = self.areDriveWheelsGrounded
-    local tiltForce = isGrounded and self.TiltForce or self.TiltForce * 0.2
-    local uprightForce = isGrounded and self.KeepUprightForce or self.KeepUprightForce * 0.5
+    local tiltForce = isAnyWheelGrounded and self.TiltForce or self.TiltForce * 0.2
+    local uprightForce = isAnyWheelGrounded and self.KeepUprightForce or self.KeepUprightForce * 0.5
 
     outAng[1] = outAng[1] + self.steerTilt * mass * tiltForce
     outAng[1] = outAng[1] + angVel[1] * mass * self.KeepUprightDrag

--- a/lua/entities/base_glide_motorcycle/init.lua
+++ b/lua/entities/base_glide_motorcycle/init.lua
@@ -97,7 +97,7 @@ function ENT:UpdateSteering( dt )
     local inputSteer = Clamp( self:GetInputFloat( 1, "steer" ), -1, 1 )
     local sideSlip = Clamp( self.avgSideSlip, -1, 1 )
 
-    local tilt = Clamp( sideSlip * -2, -0.5, 0.5 )
+    local tilt = Clamp( sideSlip * -2, -0.75, 0.75 )
 
     if isAnyWheelGrounded then
         tilt = tilt + inputSteer * Clamp( self.forwardSpeed / 300, 0, 1 )
@@ -107,7 +107,7 @@ function ENT:UpdateSteering( dt )
         end
     end
 
-    self.steerTilt = ExpDecay( self.steerTilt, tilt, 6 + invSpeedOverFactor * 3, dt )
+    self.steerTilt = ExpDecay( self.steerTilt, tilt, 8 + invSpeedOverFactor * 2, dt )
 
     if
         isAnyWheelGrounded and

--- a/lua/entities/base_glide_motorcycle/init.lua
+++ b/lua/entities/base_glide_motorcycle/init.lua
@@ -19,6 +19,7 @@ function ENT:OnPostInitialize()
     self:SetSteerConeChangeRate( 10 )
     self:SetSteerConeMaxSpeed( 1000 )
     self:SetSteerConeMaxAngle( 0.1 )
+    self:SetPowerDistribution( -1 )
 
     -- Change slip parameters to better suit bikes
     self:SetExtremumValue( 7 )

--- a/lua/entities/base_glide_motorcycle/shared.lua
+++ b/lua/entities/base_glide_motorcycle/shared.lua
@@ -12,8 +12,11 @@ ENT.VehicleType = Glide.VEHICLE_TYPE.MOTORCYCLE
 ENT.SeatDriverAnim = "drive_airboat"
 ENT.SeatPassengerAnim = "sit"
 
-ENT.AllowEditWheelRadius = false
-ENT.AllowEditSuspensionLen = false
+ENT.UneditableNWVars = {
+    WheelRadius = true,
+    SuspensionLength = true,
+    PowerDistribution = true
+}
 
 if CLIENT then
     ENT.EngineSmokeMaxZVel = 20

--- a/lua/entities/gtav_airbus.lua
+++ b/lua/entities/gtav_airbus.lua
@@ -143,16 +143,14 @@ if SERVER then
         self:CreateWheel( Vector( -165.5, 49, -15 ), {
             model = "models/gta5/vehicles/airbus/wheel_rear.mdl",
             modelAngle = Angle( 0, 0, 0 ),
-            modelScale = Vector( 1, 0.6, 1 ),
-            isPowered = true
+            modelScale = Vector( 1, 0.6, 1 )
         } )
 
         -- Rear right
         self:CreateWheel( Vector( -165.5, -49, -15 ), {
             model = "models/gta5/vehicles/airbus/wheel_rear.mdl",
             modelAngle = Angle( 0, 180, 0 ),
-            modelScale = Vector( 1, 0.6, 1 ),
-            isPowered = true
+            modelScale = Vector( 1, 0.6, 1 )
         } )
 
         self:ChangeWheelRadius( 20 )

--- a/lua/entities/gtav_airbus.lua
+++ b/lua/entities/gtav_airbus.lua
@@ -98,13 +98,17 @@ if SERVER then
         self:SetSuspensionLength( 13 )
         self:SetTransmissionEfficiency( 0.8 )
         self:SetDifferentialRatio( 1.6 )
+        self:SetPowerDistribution( -0.7 )
+
         self:SetBrakePower( 2500 )
-        self:SetWheelInertia( 10 )
+        self:SetWheelInertia( 8 )
         self:SetMaxSteerAngle( 45 )
+        self:SetSteerConeChangeRate( 6 )
+        self:SetSteerConeMaxSpeed( 700 )
 
         self:SetMinRPM( 1000 )
         self:SetMaxRPM( 8000 )
-        self:SetMinRPMTorque( 1000 )
+        self:SetMinRPMTorque( 1100 )
         self:SetMaxRPMTorque( 1200 )
 
         self:SetSlipForce( 110 )

--- a/lua/entities/gtav_blazer.lua
+++ b/lua/entities/gtav_blazer.lua
@@ -166,14 +166,14 @@ if SERVER then
         self:SetSteerConeChangeRate( 10 )
         self:SetSteerConeMaxSpeed( 1000 )
 
-        self:SetTransmissionEfficiency( 0.7 )
+        self:SetPowerDistribution( -0.7 )
         self:SetDifferentialRatio( 1.2 )
         self:SetBrakePower( 1300 )
-        self:SetWheelInertia( 6 )
+        self:SetWheelInertia( 5 )
 
         self:SetMaxRPM( 15000 )
-        self:SetMinRPMTorque( 980 )
-        self:SetMaxRPMTorque( 1000 )
+        self:SetMinRPMTorque( 1000 )
+        self:SetMaxRPMTorque( 1200 )
 
         self:SetSuspensionLength( 10 )
         self:SetSpringStrength( 450 )

--- a/lua/entities/gtav_blazer.lua
+++ b/lua/entities/gtav_blazer.lua
@@ -204,7 +204,6 @@ if SERVER then
             model = "models/gta5/vehicles/blazer/wheel.mdl",
             modelScale = Vector( 0.5, 1, 1 ),
             modelAngle = Angle( 0, 90, 0 ),
-            isPowered = true,
             enableAxleForces = true
         } )
 
@@ -213,7 +212,6 @@ if SERVER then
             model = "models/gta5/vehicles/blazer/wheel.mdl",
             modelAngle = Angle( 0, -90, 0 ),
             modelScale = Vector( 0.5, 1, 1 ),
-            isPowered = true,
             enableAxleForces = true
         } )
 

--- a/lua/entities/gtav_dukes.lua
+++ b/lua/entities/gtav_dukes.lua
@@ -79,16 +79,14 @@ if SERVER then
         self:CreateWheel( Vector( -67, 37, -5 ), {
             model = "models/gta5/vehicles/dukes/wheel.mdl",
             modelAngle = Angle( 0, 90, 0 ),
-            modelScale = Vector( 0.35, 1, 1 ),
-            isPowered = true
+            modelScale = Vector( 0.35, 1, 1 )
         } )
 
         -- Rear right
         self:CreateWheel( Vector( -67, -37, -5 ), {
             model = "models/gta5/vehicles/dukes/wheel.mdl",
             modelAngle = Angle( 0, -90, 0 ),
-            modelScale = Vector( 0.35, 1, 1 ),
-            isPowered = true
+            modelScale = Vector( 0.35, 1, 1 )
         } )
 
         self:ChangeWheelRadius( 15 )

--- a/lua/entities/gtav_gauntlet_classic.lua
+++ b/lua/entities/gtav_gauntlet_classic.lua
@@ -110,15 +110,13 @@ if SERVER then
         -- Rear left
         self:CreateWheel( Vector( -58, 36, 5 ), {
             model = "models/gta5/vehicles/gauntlet_classic/wheel.mdl",
-            modelAngle = Angle( 0, 90, 0 ),
-            isPowered = true
+            modelAngle = Angle( 0, 90, 0 )
         } )
 
         -- Rear right
         self:CreateWheel( Vector( -58, -36, 5 ), {
             model = "models/gta5/vehicles/gauntlet_classic/wheel.mdl",
-            modelAngle = Angle( 0, -90, 0 ),
-            isPowered = true
+            modelAngle = Angle( 0, -90, 0 )
         } )
 
         self:ChangeWheelRadius( 15 )

--- a/lua/entities/gtav_gauntlet_classic.lua
+++ b/lua/entities/gtav_gauntlet_classic.lua
@@ -61,7 +61,7 @@ if SERVER then
     duplicator.RegisterEntityClass( "gtav_gauntlet_classic", Glide.VehicleFactory, "Data" )
 
     ENT.SpawnPositionOffset = Vector( 0, 0, 30 )
-    ENT.BurnoutForce = 70
+    ENT.BurnoutForce = 65
 
     function ENT:GetGears()
         return {
@@ -87,8 +87,8 @@ if SERVER then
         self:SetDifferentialRatio( 1.9 )
 
         self:SetMaxRPM( 25000 )
-        self:SetMinRPMTorque( 1000 )
-        self:SetMaxRPMTorque( 1200 )
+        self:SetMinRPMTorque( 1200 )
+        self:SetMaxRPMTorque( 1400 )
 
         self:CreateSeat( Vector( -22, 18, -3 ), Angle( 0, 270, -10 ), Vector( 40, 80, 0 ), true )
         self:CreateSeat( Vector( -8, -18, -3 ), Angle( 0, 270, 5 ), Vector( -40, -80, 0 ), true )

--- a/lua/entities/gtav_sanchez.lua
+++ b/lua/entities/gtav_sanchez.lua
@@ -106,8 +106,7 @@ if SERVER then
         self:CreateWheel( Vector( -29, 0, -1 ), {
             model = "models/gta5/vehicles/blazer/wheel.mdl",
             modelScale = Vector( 0.4, 1, 1 ),
-            modelAngle = Angle( 0, 90, 0 ),
-            isPowered = true
+            modelAngle = Angle( 0, 90, 0 )
         } ):SetNoDraw( true )
 
         self:ChangeWheelRadius( 14 )

--- a/lua/entities/gtav_speedo.lua
+++ b/lua/entities/gtav_speedo.lua
@@ -51,7 +51,7 @@ if SERVER then
 
     ENT.SpawnPositionOffset = Vector( 0, 0, 50 )
     ENT.ChassisMass = 900
-    ENT.BurnoutForce = 60
+    ENT.BurnoutForce = 50
 
     ENT.AirControlForce = Vector( 0.4, 0.2, 0.1 ) -- Roll, pitch, yaw
     ENT.AirMaxAngularVelocity = Vector( 200, 200, 150 ) -- Roll, pitch, yaw
@@ -63,15 +63,18 @@ if SERVER then
     }
 
     function ENT:CreateFeatures()
-        self:SetWheelInertia( 11 )
+        self:SetWheelInertia( 10 )
         self:SetSpringStrength( 700 )
+        self:SetSteerConeMaxSpeed( 1000 )
+        self:SetAsymptoteValue( 1.5 )
 
         self:SetDifferentialRatio( 2.3 )
-        self:SetTransmissionEfficiency( 0.7 )
+        self:SetTransmissionEfficiency( 0.75 )
+        self:SetPowerDistribution( -0.75 )
         self:SetBrakePower( 3000 )
 
-        self:SetMinRPMTorque( 900 )
-        self:SetMaxRPMTorque( 1100 )
+        self:SetMinRPMTorque( 1000 )
+        self:SetMaxRPMTorque( 1200 )
 
         self:CreateSeat( Vector( 5, 22, 0 ), Angle( 0, 270, -10 ), Vector( 50, 80, 10 ), true )
         self:CreateSeat( Vector( 25, -22, 0 ), Angle( 0, 270, 5 ), Vector( 50, -80, 10 ), true )

--- a/lua/entities/gtav_speedo.lua
+++ b/lua/entities/gtav_speedo.lua
@@ -96,15 +96,13 @@ if SERVER then
         -- Rear left
         self:CreateWheel( Vector( -74, 39, -10 ), {
             model = "models/gta5/vehicles/speedo/wheel.mdl",
-            modelAngle = Angle( 0, 90, 0 ),
-            isPowered = true
+            modelAngle = Angle( 0, 90, 0 )
         } )
 
         -- Rear right
         self:CreateWheel( Vector( -74, -39, -10 ), {
             model = "models/gta5/vehicles/speedo/wheel.mdl",
-            modelAngle = Angle( 0, -90, 0 ),
-            isPowered = true
+            modelAngle = Angle( 0, -90, 0 )
         } )
 
         self:ChangeWheelRadius( 18 )

--- a/lua/entities/gtav_wolfsbane.lua
+++ b/lua/entities/gtav_wolfsbane.lua
@@ -159,8 +159,7 @@ if SERVER then
         self:CreateWheel( Vector( -32, 0, -1 ), {
             model = "models/gta5/vehicles/blazer/wheel.mdl",
             modelScale = Vector( 0.4, 1, 1 ),
-            modelAngle = Angle( 0, 90, 0 ),
-            isPowered = true
+            modelAngle = Angle( 0, 90, 0 )
         } ):SetNoDraw( true )
 
         self:ChangeWheelRadius( 14 )


### PR DESCRIPTION
- Do "is any/all wheels on ground" checks by counting how many wheels are grounded
- Figure out which wheels are in the front/rear _automagically_
- Separated available torque/brake variables for front and rear wheels
- Added `PowerDistribution` network variable
- Made burnouts work on the front wheels too
- Tweaked car/motorcycle parameters to accommodate for `PowerDistribution`
- Merged `ENT.AllowEditWheelRadius` and `ENT.AllowEditSuspensionLen` into `ENT.UneditableNWVars`