### PR TITLE
Refactor wheel traction

### DIFF
--- a/lua/entities/base_glide/sv_wheels.lua
+++ b/lua/entities/base_glide/sv_wheels.lua
@@ -17,12 +17,14 @@ function ENT:WheelInit()
         -- Brake force
         brakePower = 3000,
 
+        -- Forward traction
+        forwardTractionMax = 2600,
+
         -- Side traction
-        tractionMultiplier = 25,
-        tractionCurveMinAng = 20,
-        tractionCurveMin = 3500,
-        tractionCurveMax = 900,
-        tractionExtra = 2
+        sideTractionMultiplier = 20,
+        sideTractionMaxAng = 25,
+        sideTractionMax = 2400,
+        sideTractionMin = 800
     }
 end
 

--- a/lua/entities/base_glide_aircraft/init.lua
+++ b/lua/entities/base_glide_aircraft/init.lua
@@ -26,6 +26,13 @@ function ENT:OnPostInitialize()
     -- Countermeasure system
     self.countermeasureCD = 0
 
+    -- Update default wheel params
+    local params = self.wheelParams
+
+    params.forwardTractionMax = 50000
+    params.sideTractionMultiplier = 200
+    params.sideTractionMinAng = 70
+
     -- Trigger wire outputs
     if WireLib then
         WireLib.TriggerOutput( self, "Power", 0 )

--- a/lua/entities/base_glide_car/shared.lua
+++ b/lua/entities/base_glide_car/shared.lua
@@ -239,7 +239,12 @@ if SERVER then
     ENT.DuplicatorNetworkVariables = {
         TireSmokeColor = true,
         WheelRadius = true,
+
         MaxSteerAngle = true,
+        SteerConeChangeRate = true,
+        SteerConeMaxSpeed = true,
+        SteerConeMaxAngle = true,
+        CounterSteer = true,
 
         BrakePower = true,
         SuspensionLength = true,
@@ -260,6 +265,7 @@ if SERVER then
         MaxRPMTorque = true,
         DifferentialRatio = true,
         TransmissionEfficiency = true,
+        PowerDistribution = true,
 
         TurboCharged = true,
         FastTransmission = true

--- a/lua/entities/base_glide_car/shared.lua
+++ b/lua/entities/base_glide_car/shared.lua
@@ -91,18 +91,19 @@ function ENT:SetupDataTables()
 
     -- Make wheel parameters available as network variables too
     AddFloatVar( "WheelRadius", 10, 40, "#glide.editvar.wheels" )
-    AddFloatVar( "WheelInertia", 1, 100, "#glide.editvar.wheels" )
     AddFloatVar( "BrakePower", 500, 5000, "#glide.editvar.wheels" )
 
     AddFloatVar( "SuspensionLength", 5, 50, "#glide.editvar.suspension" )
     AddFloatVar( "SpringStrength", 100, 5000, "#glide.editvar.suspension" )
     AddFloatVar( "SpringDamper", 100, 10000, "#glide.editvar.suspension" )
 
-    AddFloatVar( "TractionBias", -1, 1, "#glide.editvar.traction" )
-    AddFloatVar( "TractionMultiplier", 5, 100, "#glide.editvar.traction" )
-    AddFloatVar( "TractionCurveMinAng", 5, 90, "#glide.editvar.traction" )
-    AddFloatVar( "TractionCurveMin", 100, 5000, "#glide.editvar.traction" )
-    AddFloatVar( "TractionCurveMax", 100, 5000, "#glide.editvar.traction" )
+    AddFloatVar( "ForwardTractionMax", 1000, 10000, "#glide.editvar.traction" )
+    AddFloatVar( "ForwardTractionBias", -1, 1, "#glide.editvar.traction" )
+
+    AddFloatVar( "SideTractionMultiplier", 5, 100, "#glide.editvar.traction" )
+    AddFloatVar( "SideTractionMaxAng", 5, 90, "#glide.editvar.traction" )
+    AddFloatVar( "SideTractionMax", 100, 5000, "#glide.editvar.traction" )
+    AddFloatVar( "SideTractionMin", 100, 5000, "#glide.editvar.traction" )
 
     if SERVER then
         -- Callback used to change the wheel radius
@@ -201,7 +202,7 @@ if SERVER then
     ENT.LightBodygroups = {}
 
     -- How much force to apply when trying to turn while doing a burnout?
-    ENT.BurnoutForce = 35
+    ENT.BurnoutForce = 70
 
     -- How much force to apply when the driver tries to unflip the vehicle?
     ENT.UnflipForce = 3
@@ -238,7 +239,6 @@ if SERVER then
     ENT.DuplicatorNetworkVariables = {
         TireSmokeColor = true,
         WheelRadius = true,
-        WheelInertia = true,
         MaxSteerAngle = true,
 
         BrakePower = true,
@@ -246,11 +246,13 @@ if SERVER then
         SpringStrength = true,
         SpringDamper = true,
 
-        TractionBias = true,
-        TractionMultiplier = true,
-        TractionCurveMinAng = true,
-        TractionCurveMin = true,
-        TractionCurveMax = true,
+        ForwardTractionMax = true,
+        ForwardTractionBias = true,
+
+        SideTractionMultiplier = true,
+        SideTractionMaxAng = true,
+        SideTractionMin = true,
+        SideTractionMax = true,
 
         MinRPM = true,
         MaxRPM = true,

--- a/lua/entities/base_glide_car/sv_engine.lua
+++ b/lua/entities/base_glide_car/sv_engine.lua
@@ -305,8 +305,8 @@ function ENT:EngineThink( dt )
         local frontBurnout = self:GetPowerDistribution() > 0
         local dir = frontBurnout and self:GetRight() or -self:GetRight()
 
-        self.frontBrake = frontBurnout and 0 or 1
-        self.rearBrake = frontBurnout and 1 or 0
+        self.frontBrake = frontBurnout and 0 or 0.5
+        self.rearBrake = frontBurnout and 0.5 or 0
 
         self.frontTractionMult = frontBurnout and 0.25 or 2
         self.rearTractionMult = frontBurnout and 2 or 0.25

--- a/lua/entities/base_glide_motorcycle/init.lua
+++ b/lua/entities/base_glide_motorcycle/init.lua
@@ -22,10 +22,9 @@ function ENT:OnPostInitialize()
     self:SetPowerDistribution( -1 )
 
     -- Change traction parameters to better suit bikes
-    self:SetTractionMultiplier( 50 )
-    self:SetTractionMinAng( 70 )
-    self:SetTractionMin( 4500 )
-    self:SetTractionMax( 3500 )
+    self:SetSideTractionMultiplier( 40 )
+    self:SetSideTractionMaxAng( 40 )
+    self:SetSideTractionMax( 1800 )
 end
 
 function ENT:SetStaySpright( toggle )

--- a/lua/entities/base_glide_motorcycle/init.lua
+++ b/lua/entities/base_glide_motorcycle/init.lua
@@ -22,11 +22,10 @@ function ENT:OnPostInitialize()
     self:SetPowerDistribution( -1 )
 
     -- Change traction parameters to better suit bikes
-    self:SetTractionBias( -0.3 )
     self:SetTractionMultiplier( 50 )
-    self:SetTractionCurveMinAng( 70 )
-    self:SetTractionCurveMin( 4500 )
-    self:SetTractionCurveMax( 3500 )
+    self:SetTractionMinAng( 70 )
+    self:SetTractionMin( 4500 )
+    self:SetTractionMax( 3500 )
 end
 
 function ENT:SetStaySpright( toggle )

--- a/lua/entities/base_glide_motorcycle/shared.lua
+++ b/lua/entities/base_glide_motorcycle/shared.lua
@@ -11,7 +11,8 @@ ENT.VehicleType = Glide.VEHICLE_TYPE.MOTORCYCLE
 ENT.UneditableNWVars = {
     WheelRadius = true,
     SuspensionLength = true,
-    PowerDistribution = true
+    PowerDistribution = true,
+    ForwardTractionBias = true
 }
 
 --- Override this base class function.

--- a/lua/entities/base_glide_tank/init.lua
+++ b/lua/entities/base_glide_tank/init.lua
@@ -28,9 +28,9 @@ function ENT:OnPostInitialize()
     params.springDamper = 30000
 
     params.tractionMultiplier = 800
-    params.tractionCurveMinAng = 70
-    params.tractionCurveMin = 25000.0
-    params.tractionCurveMax = 22000.0
+    params.tractionMinAng = 70
+    params.tractionMin = 25000.0
+    params.tractionMax = 22000.0
 
     self:SetEngineThrottle( 0 )
     self:SetEnginePower( 0 )

--- a/lua/entities/base_glide_tank/init.lua
+++ b/lua/entities/base_glide_tank/init.lua
@@ -27,10 +27,11 @@ function ENT:OnPostInitialize()
     params.springStrength = 6000
     params.springDamper = 30000
 
-    params.tractionMultiplier = 800
-    params.tractionMinAng = 70
-    params.tractionMin = 25000.0
-    params.tractionMax = 22000.0
+    params.forwardTractionMax = 50000
+    params.sideTractionMultiplier = 800
+    params.sideTractionMinAng = 70
+    params.sideTractionMax = 12000
+    params.sideTractionMin = 10000
 
     self:SetEngineThrottle( 0 )
     self:SetEnginePower( 0 )

--- a/lua/entities/gtav_airbus.lua
+++ b/lua/entities/gtav_airbus.lua
@@ -60,7 +60,7 @@ if SERVER then
     ENT.ChassisMass = 1800
     ENT.IsHeavyVehicle = true
 
-    ENT.BurnoutForce = 30
+    ENT.BurnoutForce = 20
     ENT.UnflipForce = 4
 
     ENT.AirControlForce = Vector( 0.1, 0.05, 0.1 ) -- Roll, pitch, yaw
@@ -94,15 +94,13 @@ if SERVER then
         self:SetSpringDamper( 6000 )
 
         self:SetSuspensionLength( 13 )
-        self:SetTransmissionEfficiency( 0.8 )
         self:SetDifferentialRatio( 1.6 )
         self:SetPowerDistribution( -0.7 )
 
         self:SetBrakePower( 2500 )
-        self:SetWheelInertia( 8 )
         self:SetMaxSteerAngle( 60 )
         self:SetSteerConeChangeRate( 6 )
-        self:SetSteerConeMaxSpeed( 500 )
+        self:SetSteerConeMaxSpeed( 800 )
         self:SetSteerConeMaxAngle( 0.2 )
 
         self:SetMinRPM( 1000 )
@@ -110,10 +108,9 @@ if SERVER then
         self:SetMinRPMTorque( 1100 )
         self:SetMaxRPMTorque( 1200 )
 
-        self:SetTractionBias( -0.25 )
-        self:SetTractionMultiplier( 60 )
-        self:SetTractionCurveMin( 3000 )
-        self:SetTractionCurveMax( 2500 )
+        self:SetForwardTractionMax( 3000 )
+        self:SetSideTractionMax( 3000 )
+        self:SetSideTractionMin( 2500 )
 
         self:CreateSeat( Vector( 230, 35.5, -4 ), Angle( 0, 270, -5 ), Vector( 250, -100, 5 ), true )
 

--- a/lua/entities/gtav_blazer.lua
+++ b/lua/entities/gtav_blazer.lua
@@ -141,7 +141,7 @@ if SERVER then
     ENT.SuspensionHeavySound = "Glide.Suspension.CompressBike"
     ENT.StartupTime = 0.4
 
-    ENT.BurnoutForce = 80
+    ENT.BurnoutForce = 150
 
     ENT.AirControlForce = Vector( 3, 2, 0.2 ) -- Roll, pitch, yaw
     ENT.AirMaxAngularVelocity = Vector( 400, 400, 150 ) -- Roll, pitch, yaw
@@ -164,16 +164,12 @@ if SERVER then
     }
 
     function ENT:CreateFeatures()
-        self:SetSteerConeMaxAngle( 0.3 )
+        self:SetSteerConeMaxAngle( 0.2 )
         self:SetSteerConeMaxSpeed( 800 )
-
-        self:SetTractionBias( 0 )
-        self:SetTractionCurveMin( 2500 )
 
         self:SetPowerDistribution( -0.7 )
         self:SetDifferentialRatio( 1.2 )
         self:SetBrakePower( 1300 )
-        self:SetWheelInertia( 5 )
 
         self:SetMaxRPM( 15000 )
         self:SetMinRPMTorque( 1000 )
@@ -182,6 +178,10 @@ if SERVER then
         self:SetSuspensionLength( 10 )
         self:SetSpringStrength( 450 )
         self:SetSpringDamper( 2800 )
+
+        self:SetSideTractionMultiplier( 15 )
+        self:SetSideTractionMax( 2400 )
+        self:SetSideTractionMin( 500 )
 
         self:CreateSeat( Vector( -23, 0, 4 ), Angle( 0, 270, -16 ), Vector( 0, 60, 0 ), true )
 

--- a/lua/entities/gtav_gauntlet_classic.lua
+++ b/lua/entities/gtav_gauntlet_classic.lua
@@ -59,7 +59,7 @@ end
 
 if SERVER then
     ENT.SpawnPositionOffset = Vector( 0, 0, 30 )
-    ENT.BurnoutForce = 40
+    ENT.BurnoutForce = 80
 
     function ENT:GetGears()
         return {
@@ -81,13 +81,13 @@ if SERVER then
     }
 
     function ENT:CreateFeatures()
-        self:SetWheelInertia( 10 )
         self:SetDifferentialRatio( 1.9 )
-        self:SetTractionMultiplier( 30 )
 
         self:SetMaxRPM( 25000 )
-        self:SetMinRPMTorque( 1200 )
-        self:SetMaxRPMTorque( 1400 )
+        self:SetMinRPMTorque( 1300 )
+        self:SetMaxRPMTorque( 1500 )
+
+        self:SetForwardTractionMax( 2500 )
 
         self:CreateSeat( Vector( -22, 18, -3 ), Angle( 0, 270, -10 ), Vector( 40, 80, 0 ), true )
         self:CreateSeat( Vector( -8, -18, -3 ), Angle( 0, 270, 5 ), Vector( -40, -80, 0 ), true )

--- a/lua/entities/gtav_insurgent.lua
+++ b/lua/entities/gtav_insurgent.lua
@@ -181,7 +181,6 @@ if SERVER then
     }
 
     function ENT:CreateFeatures()
-        self:SetWheelInertia( 11.5 )
         self:SetBrakePower( 3800 )
         self:SetDifferentialRatio( 3.3 )
         self:SetPowerDistribution( -0.4 )
@@ -193,8 +192,8 @@ if SERVER then
         self:SetSpringStrength( 500 )
         self:SetSpringDamper( 2500 )
 
-        self:SetTractionCurveMinAng( 30 )
-        self:SetTractionCurveMax( 1000 )
+        self:SetForwardTractionMax( 3000 )
+        self:SetSideTractionMin( 1000 )
 
         self:CreateSeat( Vector( -2, 21.5, 9 ), Angle( 0, 270, -5 ), Vector( 40, 100, 0 ), true )
         self:CreateSeat( Vector( 15, -21.5, 7 ), Angle( 0, 270, 5 ), Vector( 40, -100, 0 ), true )

--- a/lua/entities/gtav_sanchez.lua
+++ b/lua/entities/gtav_sanchez.lua
@@ -68,7 +68,7 @@ end
 if SERVER then
     ENT.SpawnPositionOffset = Vector( 0, 0, 40 )
     ENT.StartupTime = 0.4
-    ENT.BurnoutForce = 200
+    ENT.BurnoutForce = 220
 
     ENT.LightBodygroups = {
         { type = "headlight", bodyGroupId = 6, subModelId = 1 }, -- Headlight
@@ -79,7 +79,6 @@ if SERVER then
         self:SetTransmissionEfficiency( 0.7 )
         self:SetDifferentialRatio( 1.8 )
         self:SetBrakePower( 2000 )
-        self:SetWheelInertia( 9 )
 
         self:SetMaxRPM( 15000 )
         self:SetMinRPMTorque( 500 )

--- a/lua/entities/gtav_speedo.lua
+++ b/lua/entities/gtav_speedo.lua
@@ -49,7 +49,7 @@ end
 if SERVER then
     ENT.SpawnPositionOffset = Vector( 0, 0, 50 )
     ENT.ChassisMass = 900
-    ENT.BurnoutForce = 30
+    ENT.BurnoutForce = 35
 
     ENT.AirControlForce = Vector( 0.4, 0.2, 0.1 ) -- Roll, pitch, yaw
     ENT.AirMaxAngularVelocity = Vector( 200, 200, 150 ) -- Roll, pitch, yaw
@@ -61,15 +61,15 @@ if SERVER then
     }
 
     function ENT:CreateFeatures()
-        self:SetWheelInertia( 10 )
         self:SetSpringStrength( 700 )
         self:SetSteerConeMaxSpeed( 1000 )
-        self:SetTractionBias( -0.15 )
+        self:SetForwardTractionBias( -0.15 )
+        self:SetForwardTractionMax( 2900 )
 
         self:SetDifferentialRatio( 2.3 )
         self:SetTransmissionEfficiency( 0.75 )
         self:SetPowerDistribution( 0.8 )
-        self:SetBrakePower( 3000 )
+        self:SetBrakePower( 2500 )
 
         self:SetMinRPMTorque( 1000 )
         self:SetMaxRPMTorque( 1200 )

--- a/lua/entities/gtav_strikeforce.lua
+++ b/lua/entities/gtav_strikeforce.lua
@@ -211,7 +211,7 @@ if SERVER then
         self.wheelParams.springStrength = 1500
         self.wheelParams.springDamper = 6000
         self.wheelParams.brakePower = 2000
-        self.wheelParams.tractionMultiplier = 40
+        self.wheelParams.sideTractionMultiplier = 250
 
         -- Front
         self:CreateWheel( Vector( 180, -12, -25 ), {

--- a/lua/entities/gtav_wolfsbane.lua
+++ b/lua/entities/gtav_wolfsbane.lua
@@ -132,9 +132,7 @@ if SERVER then
         self:SetTransmissionEfficiency( 0.65 )
         self:SetDifferentialRatio( 1.8 )
         self:SetBrakePower( 2000 )
-        self:SetWheelInertia( 9 )
         self:SetMaxSteerAngle( 25 )
-        self:SetTractionBias( -0.35 )
 
         self:SetMaxRPM( 15000 )
         self:SetMinRPMTorque( 500 )

--- a/lua/glide/server/util.lua
+++ b/lua/glide/server/util.lua
@@ -97,16 +97,16 @@ do
 end
 
 do
-    -- Traction curve logic
-    local Pow = math.pow
-    local ay, bx, by = 1.0, 0.5, 0.25
+    -- Traction logic
+    local ay, bx, by, xx = 0, 0, 0, 0
 
     function Glide.SetupTraction( t )
-        ay, bx, by = t.tractionCurveMin, t.tractionCurveMinAng / 90, t.tractionCurveMax
+        ay, bx, by = t.sideTractionMax, t.sideTractionMaxAng / 90, t.sideTractionMin
     end
 
-    function Glide.TractionCurve( x )
-        return x > bx and by or ( 3 * Pow( x / bx, 2 ) - 2 * Pow( x / bx, 3 ) ) * ( by - ay ) + ay
+    function Glide.TractionRamp( x )
+        xx = ( x - bx ) / ( 1 - bx )
+        return x < bx and ay or ( ay * ( 1 - xx ) ) + ( by * xx )
     end
 end
 


### PR DESCRIPTION
This overhauls the forward/sideways traction forces, allowing cars to drift and turn fast on tight corners.

- Removed the `WheelInertia` NW variable
- Added `ForwardTractionMax`
- `Glide.TractionCurve` was replaced by `Glide.TractionRamp`
- Renamed `TractionBias` to `ForwardTractionBias`
- Renamed `TractionMultiplier` to `SideTractionMultiplier`
- Renamed `TractionCurveMinAng` to `SideTractionMaxAng`
- Renamed `TractionCurveMin` to `SideTractionMax`
- Renamed `TractionCurveMax` to `SideTractionMin`
- Removed the `enableTorqueInertia` variable from wheels

 _(The min/max swap is intentional, since we moved from a traction curve to a traction ramp)_