### PR TITLE
Allow you to redefine vehicle spawn colors, again

### DIFF
--- a/lua/entities/base_glide/init.lua
+++ b/lua/entities/base_glide/init.lua
@@ -9,18 +9,6 @@ include( "sv_wheels.lua" )
 
 duplicator.RegisterEntityClass( "base_glide", Glide.VehicleFactory, "Data" )
 
-ENT.VehicleColors = {
-    Color( 180, 70, 70 ),
-    Color( 80, 65, 50 ),
-    Color( 162, 188, 243 ),
-    Color( 214, 106, 53 ),
-    Color( 45, 45, 45 ),
-    Color( 20, 20, 20 ),
-    Color( 100, 100, 100 ),
-    Color( 190, 190, 190 ),
-    Color( 255, 255, 255 )
-}
-
 local EntityMeta = FindMetaTable( "Entity" )
 local getTable = EntityMeta.GetTable
 
@@ -111,7 +99,7 @@ function ENT:Initialize()
         return
     end
 
-    local data = { Color = self.VehicleColors[math.random( #self.VehicleColors )] }
+    local data = { Color = self:GetSpawnColor() }
 
     self:SetColor( data.Color )
     duplicator.StoreEntityModifier( self, "colour", data )
@@ -528,4 +516,20 @@ function ENT:TriggerInput( name, value )
     elseif name == "LockVehicle" then
         self:SetLocked( value > 0, true )
     end
+end
+
+local colors = {
+    Color( 180, 70, 70 ),
+    Color( 80, 65, 50 ),
+    Color( 162, 188, 243 ),
+    Color( 214, 106, 53 ),
+    Color( 45, 45, 45 ),
+    Color( 20, 20, 20 ),
+    Color( 100, 100, 100 ),
+    Color( 190, 190, 190 ),
+    Color( 255, 255, 255 )
+}
+
+function ENT:GetSpawnColor()
+    return colors[math.random( #colors )]
 end


### PR DESCRIPTION
i'm terribly sorry, the last pull request wasn't tested properly. Turns out that baseclasses alter the behavior when redefining a table in the `ENT` struct (table in child class gets merged with table in parent class instead of overwriting among other things). I can't find any info about this on the gmod wiki, so i just added a `ENT:GetSpawnColor()` method instead