### PR TITLE
Weapon support for sit sequences

### DIFF
--- a/lua/glide/sh_anims.lua
+++ b/lua/glide/sh_anims.lua
@@ -43,6 +43,28 @@ hook.Add( "CalcMainActivity", "Glide.OverridePlayerActivity", function( ply )
     plyTbl.CalcIdeal = 47 -- ACT_STAND
     plyTbl.CalcSeqOverride = ply:LookupSequence( anim )
 
+    -- Just because we aren't a driver doesn't mean the vehicle can't have a custom sequence.
+    if anim == "sit" and ply ~= vehicle:GetDriver() and ply:GetAllowWeaponsInVehicle() then
+        local activeWep = ply:GetActiveWeapon()
+
+        if not IsValid( activeWep ) or activeWep == NULL then
+            return plyTbl.CalcIdeal, plyTbl.CalcSeqOverride
+        end
+
+        local holdType = activeWep:GetHoldType()
+
+        if holdType == "smg" then
+            holdType = "smg1"
+        end
+
+        local sequenceID = ply:LookupSequence( string.format( sitFormat, holdType ) )
+
+        if sequenceID ~= -1 then
+            plyTbl.CalcIdeal = 1970 -- ACT_HL2MP_SIT
+            plyTbl.CalcSeqOverride = sequenceID
+        end
+    end
+
     return plyTbl.CalcIdeal, plyTbl.CalcSeqOverride
 end )
 

--- a/lua/glide/sh_anims.lua
+++ b/lua/glide/sh_anims.lua
@@ -21,6 +21,22 @@ hook.Add( "UpdateAnimation", "Glide.OverridePlayerAnim", function( ply )
     end
 end )
 
+local holdTypeSequences = {
+    ["pistol"] = "sit_pistol",
+    ["smg"] = "sit_smg1",
+    ["grenade"] = "sit_grenade",
+    ["ar2"] = "sit_ar2",
+    ["shotgun"] = "sit_shotgun",
+    ["rpg"] = "sit_rpg",
+    ["physgun"] = "sit_physgun",
+    ["crossbow"] = "sit_crossbow",
+    ["melee"] = "sit_melee",
+    ["slam"] = "sit_slam",
+    ["fist"] = "sit_fist",
+    ["camera"] = "sit_camera",
+    ["passive"] = "sit_passive"
+}
+
 hook.Add( "CalcMainActivity", "Glide.OverridePlayerActivity", function( ply )
     local vehicle = ply:GlideGetVehicle()
 
@@ -43,8 +59,8 @@ hook.Add( "CalcMainActivity", "Glide.OverridePlayerActivity", function( ply )
     plyTbl.CalcIdeal = 47 -- ACT_STAND
     plyTbl.CalcSeqOverride = ply:LookupSequence( anim )
 
-    -- Just because we aren't a driver doesn't mean the vehicle can't have a custom sequence.
-    if anim == "sit" and ply ~= vehicle:GetDriver() and ply:GetAllowWeaponsInVehicle() then
+    -- We only apply a sit sequence when the vehicle actually uses one.
+    if anim == "sit" and ply:GetAllowWeaponsInVehicle() then
         local activeWep = ply:GetActiveWeapon()
 
         if not IsValid( activeWep ) or activeWep == NULL then
@@ -52,16 +68,16 @@ hook.Add( "CalcMainActivity", "Glide.OverridePlayerActivity", function( ply )
         end
 
         local holdType = activeWep:GetHoldType()
+        local sitSequence = holdTypeSequences[holdType]
 
-        if holdType == "smg" then
-            holdType = "smg1"
-        end
+        -- Not every hold type has a corresponding sit sequence.
+        if sitSequence then
+            local sequenceID = ply:LookupSequence( sitSequence )
 
-        local sequenceID = ply:LookupSequence( string.format( sitFormat, holdType ) )
-
-        if sequenceID ~= -1 then
-            plyTbl.CalcIdeal = 1970 -- ACT_HL2MP_SIT
-            plyTbl.CalcSeqOverride = sequenceID
+            if sequenceID ~= -1 then
+                plyTbl.CalcIdeal = 1970 -- ACT_HL2MP_SIT
+                plyTbl.CalcSeqOverride = sequenceID
+            end
         end
     end
 


### PR DESCRIPTION
Tested on a listen server, works well. I recommend caching the ent/player functions as CalcMainActivity is a very expensive hook and lowering __index calls is an easy way to save on performance.

![image](https://github.com/user-attachments/assets/c1dad868-d3fd-474f-993b-e09043802b57)
