### PR TITLE
Allow you to define thirdperson camera center offset

### DIFF
--- a/lua/entities/base_glide/shared.lua
+++ b/lua/entities/base_glide/shared.lua
@@ -82,6 +82,7 @@ if CLIENT then
 
     -- Setup the camera parameters for this vehicle
     ENT.CameraOffset = Vector( -200, 0, 50 )
+    ENT.CameraCenterOffset = Vector( 0, 0, 0 )
     ENT.CameraAngleOffset = Angle( 6, 0, 0 )
 
     -- Setup how far away players can hear sounds and update misc. features
@@ -90,14 +91,14 @@ if CLIENT then
 
     -- Set label/icons for each weapon slot.
     -- This should contain a array of tables, where each table looks like these:
-    -- 
+    --
     -- { name = "Machine Guns", icon = "glide/icons/bullets.png" }
     -- { name = "Missiles", icon = "glide/icons/rocket.png" }
     ENT.WeaponInfo = {}
 
     -- Set crosshair parameters per weapon slot.
     -- This should contain a array of tables, where each table looks like these:
-    -- 
+    --
     -- { iconType = "dot", traceOrigin = Vector() }
     -- { iconType = "square", traceOrigin = Vector(), traceAngle = Angle(), size = 0.1 }
     ENT.CrosshairInfo = {}
@@ -183,7 +184,7 @@ if SERVER then
 
     -- Setup available weapon slots.
     -- Should contain a array of tables, where each table looks like this:
-    -- 
+    --
     -- { maxAmmo = 0, fireRate = 0.02 }
     -- { maxAmmo = 2, fireRate = 1.0, replenishDelay = 2, ammoType = "missile" }
     ENT.WeaponSlots = {}

--- a/lua/glide/client/camera.lua
+++ b/lua/glide/client/camera.lua
@@ -320,7 +320,7 @@ function Camera:CalcView()
     else
         local fraction = self.traceFraction
         local offset = self.shakeOffset + vehicle.CameraOffset * Vector( Config.cameraDistance, 1, Config.cameraHeight ) * fraction
-        local startPos = vehicle:GetPos()
+        local startPos = vehicle:LocalToWorld( vehicle.CameraCenterOffset )
 
         angles = angles + vehicle.CameraAngleOffset
 


### PR DESCRIPTION
Currently, third person camera is always centered around the entity origin, which can be undesirable and lead to problems such as  the camera getting stuck in the ground on vehicles with certain models
Allowing you to define a custom camera center offset should help with this issue

Model origin of Speedo:
![20241227162457_1](https://github.com/user-attachments/assets/4cad6dd7-a9eb-46fd-b4a5-ee90a8703fa1)
Model origin of simfphys Volga:
![20241227162507_1](https://github.com/user-attachments/assets/692d6440-3bde-41c0-81c1-ef7c2144d5da)
Model origin of LFS BF 109:
![20241227162530_1](https://github.com/user-attachments/assets/5a0dbb0d-018a-47a9-a8f1-d99d45e96811)
Camera getting stuck inside ground on LFS BF 109:
![20241227162535_1](https://github.com/user-attachments/assets/6195bf57-3e6c-47fb-8322-3138132ad3da)
