### PR TITLE
Rotorwash fix

### DIFF
--- a/lua/entities/base_glide/init.lua
+++ b/lua/entities/base_glide/init.lua
@@ -541,3 +541,6 @@ function ENT:GetSpawnColor()
     local color = colors[math.random( #colors )]
     return Color( color.r, color.g, color.b )
 end
+
+function ENT:RotorStartSpinningFast( _rotor ) end
+function ENT:RotorStopSpinningFast( _rotor ) end

--- a/lua/entities/base_glide_aircraft/init.lua
+++ b/lua/entities/base_glide_aircraft/init.lua
@@ -502,3 +502,11 @@ function ENT:TriggerInput( name, value )
         self:SelectWeaponIndex( Clamp( value, 1, self.weaponCount ) )
     end
 end
+
+function ENT:RotorStartSpinningFast( rotor )
+    rotor:SetModel( rotor.modelFast or rotor.modelSlow )
+end
+
+function ENT:RotorStopSpinningFast( rotor )
+    rotor:SetModel( rotor.modelSlow )
+end

--- a/lua/entities/base_glide_heli/init.lua
+++ b/lua/entities/base_glide_heli/init.lua
@@ -249,10 +249,12 @@ function ENT:OnSimulatePhysics( phys, _, outLin, outAng )
 end
 
 
-function ENT:RotorStartSpinningFast( _rotor )
+function ENT:RotorStartSpinningFast( rotor )
+    BaseClass.RotorStartSpinningFast( self, rotor )
     self:CreateRotorWash()
 end
 
-function ENT:RotorStopSpinningFast( _rotor )
+function ENT:RotorStopSpinningFast( rotor )
+    BaseClass.RotorStopSpinningFast( self, rotor )
     self:RemoveRotorWash()
 end

--- a/lua/entities/base_glide_heli/init.lua
+++ b/lua/entities/base_glide_heli/init.lua
@@ -40,7 +40,7 @@ function ENT:Repair()
         self.mainRotor:SetBaseAngles( self.MainRotorAngle )
     end
 
-    -- Create tail rotor, if it doesn't exist and we have a model for it 
+    -- Create tail rotor, if it doesn't exist and we have a model for it
     if not IsValid( self.tailRotor ) then
         self.tailRotor = self:CreateRotor( self.TailRotorOffset, self.TailRotorRadius, self.TailRotorModel, self.TailRotorFastModel )
         self.tailRotor:SetBaseAngles( self.TailRotorAngle )
@@ -246,4 +246,13 @@ function ENT:OnSimulatePhysics( phys, _, outLin, outAng )
         local effectiveness = Clamp( power, 0, self:GetOutOfControl() and 0.5 or 1 )
         self:SimulateHelicopter( phys, params, effectiveness, outLin, outAng )
     end
+end
+
+
+function ENT:RotorStartSpinningFast( _rotor )
+    self:CreateRotorWash()
+end
+
+function ENT:RotorStopSpinningFast( _rotor )
+    self:RemoveRotorWash()
 end

--- a/lua/entities/glide_rotor.lua
+++ b/lua/entities/glide_rotor.lua
@@ -136,11 +136,10 @@ function ENT:Think()
 
     if self.isSpinningFast ~= isSpinningFast then
         self.isSpinningFast = isSpinningFast
-        self:SetModel( isSpinningFast and self.modelFast or self.modelSlow )
         if isSpinningFast then
-            self:GetParent():CreateRotorWash()
+            self:GetParent():RotorStartSpinningFast( self )
         else
-            self:GetParent():RemoveRotorWash()
+            self:GetParent():RotorStopSpinningFast( self )
         end
     end
 


### PR DESCRIPTION
Recent commit added waterwash to helicopter rotors. The problem is that planes can use rotots too, but they don't have ENT:CreateWaterWash() defined (and why would they?), so they break (including gtav_stunt). This commit makes rotors delegate fast spinning logic to their parent. This allows you to define some custom logic too, such as rotors changing bodygroups instead of changing models.

NOTE: I think this is getting kinda messy. Perhaps it would be better to not define this logic on base_glide_aircraft and base_glide_heli, and just do all of this on the actual vehicles? This kind of logic seems pretty vehicle-specific to me.