### PR TITLE
Whitelist **empty** for skybox

### DIFF
--- a/lua/entities/glide_rotor.lua
+++ b/lua/entities/glide_rotor.lua
@@ -177,8 +177,9 @@ function ENT:CheckRotorClearance( dt, parent )
 
     local tr = TraceHull( data )
 
-    if tr.Hit and not tr.HitSky and not tr.HitNoDraw then
+    if tr.Hit and not tr.HitSky and not tr.HitNoDraw and tr.HitTexture ~= "**empty**" then
         self:OnRotorHit( tr.Entity, tr.HitPos, origin )
+        return
     end
 
     -- Another trace on the opposite direction
@@ -186,8 +187,9 @@ function ENT:CheckRotorClearance( dt, parent )
 
     tr = TraceHull( data )
 
-    if tr.Hit and not tr.HitSky and not tr.HitNoDraw then
+    if tr.Hit and not tr.HitSky and not tr.HitNoDraw and tr.HitTexture ~= "**empty**" then
         self:OnRotorHit( tr.Entity, tr.HitPos, origin )
+        return
     end
 end
 


### PR DESCRIPTION
Currently flying a helicopter into the skybox can still result in the rotor breaking off, also makes it return early so damage isn't applied twice.

This for example would trigger the bug
![image](https://github.com/user-attachments/assets/9862afe1-02b2-4877-b4be-683764887627)

An example trace of the case above
```
["AllSolid"]	=	false
["Contents"]	=	1
["DispFlags"]	=	0
["Entity"]	=	Entity [0][worldspawn]
["Fraction"]	=	1
["FractionLeftSolid"]	=	0.32773450016975
["Hit"]	=	true
["HitBox"]	=	0
["HitGroup"]	=	0
["HitNoDraw"]	=	false
["HitNonWorld"]	=	false
["HitNormal"]	=	0.000000 0.000000 0.000000
["HitPos"]	=	-5493.462891 5308.244629 2849.267822
["HitSky"]	=	false
["HitTexture"]	=	**empty**
["HitWorld"]	=	true
["MatType"]	=	67
["Normal"]	=	-0.784633 0.404783 -0.469576
["PhysicsBone"]	=	0
["StartPos"]	=	-5322.031250 5219.805176 2951.863770
["StartSolid"]	=	true
["SurfaceFlags"]	=	0
["SurfaceProps"]	=	0
```

I think what's happening is that the trace starts in the world so it hits a inside of a brush.