### PR TITLE
Fix glide_gib_lifetime not respecting 0

### DIFF
--- a/lua/entities/glide_gib.lua
+++ b/lua/entities/glide_gib.lua
@@ -66,7 +66,12 @@ function ENT:Initialize()
         phys:SetDragCoefficient( 1 )
     end
 
-    self.lifeTime = RealTime() + lifetimeCvar:GetFloat()
+    local lifetime = lifetimeCvar:GetFloat()
+    if lifetime == 0 then
+        self.lifeTime = 0
+    else
+        self.lifeTime = RealTime() + lifetime
+    end
 end
 
 function ENT:OnRemove()

--- a/lua/entities/glide_gib.lua
+++ b/lua/entities/glide_gib.lua
@@ -115,11 +115,13 @@ function ENT:StopFire()
 end
 
 function ENT:Think()
-    local t = RealTime()
+    if self.lifeTime ~= 0 then
+        local t = RealTime()
 
-    if t > self.lifeTime and self.lifeTime ~= 0 then
-        self:Remove()
-        return
+        if t > self.lifeTime then
+            self:Remove()
+            return
+        end
     end
 
     if IsValid( self.fire ) then


### PR DESCRIPTION
Convar `glide_gib_lifetime` states `Lifetime of Glide Gibs, 0 for no despawning.` however it doesn't actually respect the value of 0 due to how it's setup on initialize, this simple commit fixes it.
