### PR TITLE
Do watersplash trace for Glide.FireBullet

### DIFF
--- a/lua/glide/server/weaponry.lua
+++ b/lua/glide/server/weaponry.lua
@@ -91,6 +91,24 @@ do
 
         if tr.Hit then
             length = length * tr.Fraction
+
+            local waterTrace = TraceLine( {
+                start = traceData.start,
+                endpos = traceData.endpos,
+                mask = MASK_WATER
+            } )
+
+            if waterTrace.Hit then
+                local eff = EffectData()
+                eff:SetOrigin( waterTrace.HitPos )
+                eff:SetScale( 13 )
+
+                if bit.band( waterTrace.Contents, CONTENTS_SLIME ) == 0 then
+                    eff:SetFlags( 0 )
+                end
+
+                Effect( "watersplash", eff )
+            end
         end
 
         if params.isExplosive then


### PR DESCRIPTION
Currently the trace passes through water and has no effect which seems kinda janky
After looking at how the engine does it for firebullet i implemented a lua way of doing it

![image](https://github.com/user-attachments/assets/d110221d-d35d-4950-ba80-4e61b3f152fb)
