### PR TITLE
Prevent glide_missile damaging glide_missile

### DIFF
--- a/lua/entities/glide_missile.lua
+++ b/lua/entities/glide_missile.lua
@@ -280,6 +280,12 @@ function ENT:PhysicsCollide()
     self:Explode()
 end
 
-function ENT:OnTakeDamage()
+function ENT:OnTakeDamage( dmginfo )
+    if dmginfo:IsExplosionDamage() then
+        local inflictor = dmginfo:GetInflictor()
+        if IsValid( inflictor ) and inflictor:GetClass() == "glide_missile" then
+            return
+        end
+    end
     if not self.hasExploded then self:Explode() end
 end


### PR DESCRIPTION
Currently glide missiles can blow each other up all at once, wasting missile as they explode in the air instead of on the shot at taget. it's pretty noticeable if you use the gtav_strikeforce jet and fire the barrage while flying downwards.

Maybe blocking explosive damage entirely could work too but i figured being more restrictive would be the best.