### PR TITLE
Delete projectiles/missiles on skybox hit

### DIFF
--- a/lua/entities/glide_missile.lua
+++ b/lua/entities/glide_missile.lua
@@ -277,7 +277,11 @@ function ENT:Think()
     return true
 end
 
-function ENT:PhysicsCollide()
+function ENT:PhysicsCollide( data )
+    if data.TheirSurfaceProps == 76 then
+        self:Remove()
+        return
+    end
     self:Explode()
 end
 

--- a/lua/entities/glide_projectile.lua
+++ b/lua/entities/glide_projectile.lua
@@ -158,6 +158,11 @@ function ENT:Think()
 
     local tr = TraceLine( traceData )
 
+    if tr.HitSky then
+        self:Remove()
+        return
+    end
+
     if tr.Hit then
         self:Explode()
         return
@@ -170,7 +175,12 @@ function ENT:Think()
     return true
 end
 
-function ENT:PhysicsCollide()
+function ENT:PhysicsCollide( data )
+    print( "PhysicsCollide", data.HitEntity, data.HitEntity:GetClass() )
+    if data.TheirSurfaceProps == 76 then
+        self:Remove()
+        return
+    end
     self:Explode()
 end
 

--- a/lua/entities/glide_projectile.lua
+++ b/lua/entities/glide_projectile.lua
@@ -176,7 +176,6 @@ function ENT:Think()
 end
 
 function ENT:PhysicsCollide( data )
-    print( "PhysicsCollide", data.HitEntity, data.HitEntity:GetClass() )
     if data.TheirSurfaceProps == 76 then
         self:Remove()
         return


### PR DESCRIPTION
Currently missiles and projectiles explode when they hit the skybox, this pr makes it so they delete themselves instead like for example the hl2 rocket launcher does.