### PR TITLE
Add cant fire state and reset lock on reload

### DIFF
--- a/lua/weapons/glide_homing_launcher.lua
+++ b/lua/weapons/glide_homing_launcher.lua
@@ -266,6 +266,7 @@ if CLIENT then
     local AIM_ICON = "glide/aim_square.png"
 
     local LOCKON_STATE_COLORS = {
+        [-1] = Color( 220, 220, 220, 100 ),
         [0] = Color( 255, 255, 255 ),
         [1] = Color( 255, 255, 255 ),
         [2] = Color( 100, 255, 100 ),
@@ -345,6 +346,12 @@ function SWEP:UpdateTarget()
     if user:IsBot() then return end
 
     local t = CurTime()
+
+    if not self:CanAttack() then
+        self:SetLockTarget( NULL )
+        self:SetLockState( -1 )
+        return
+    end
 
     if not user:KeyDown( IN_ATTACK2 ) then
         self:SetLockTarget( NULL )

--- a/lua/weapons/glide_homing_launcher.lua
+++ b/lua/weapons/glide_homing_launcher.lua
@@ -142,6 +142,10 @@ function SWEP:CanAttack()
         return false
     end
 
+    if self:GetNextPrimaryFire() > CurTime() then
+        return false
+    end
+
     return true
 end
 


### PR DESCRIPTION
Makes it so the crosshair greys out when you cant fire, also resets the lock after shooting just like GTA V.
Resetting the 

https://github.com/user-attachments/assets/5516aa14-d4bf-4738-b2c5-dbb3c82da8ad

lock when you can't fire is also more fair in pvp.

Source:
https://www.youtube.com/watch?v=cBtOAAsDKKE&t=123s