### PR TITLE
Do parent lookup for prop_vehicle_prisoner_pod, make logic cleaner

### DIFF
--- a/lua/glide/server/weaponry.lua
+++ b/lua/glide/server/weaponry.lua
@@ -263,11 +263,14 @@ local WHITELIST = Glide.LOCKON_WHITELIST
 --- then returns which one has the largest dot product between `normal` and the direction towards them.
 local function isLockableEntity( ent, skipParentCheck )
     local class = getClass( ent )
-    if not skipParentCheck and class == "prop_vehicle_prisoner_pod" then
-        if isLockableEntity( getParent( ent ), true ) then -- Checks for parent vehicles like for example glide
-            return false
+    if class == "prop_vehicle_prisoner_pod" and not skipParentCheck then -- Checks for parent vehicles like for example glide
+        local parent = getParent( ent )
+        if IsValid( parent ) then
+            if isLockableEntity( parent, true ) then
+                return false
+            end
+            return true
         end
-        return true
     end
 
     if WHITELIST[class] then

--- a/lua/glide/server/weaponry.lua
+++ b/lua/glide/server/weaponry.lua
@@ -265,7 +265,7 @@ local function isLockableEntity( ent, skipParentCheck )
     local class = getClass( ent )
     if class == "prop_vehicle_prisoner_pod" and not skipParentCheck then -- Checks for parent vehicles like for example glide
         local parent = getParent( ent )
-        if parent ~= NULL then
+        if parent ~= NULL then -- Check directly against NULL as getParent returns a clean NULL object and it's faster than IsValid
             if isLockableEntity( parent, true ) then
                 return false
             end

--- a/lua/glide/server/weaponry.lua
+++ b/lua/glide/server/weaponry.lua
@@ -265,7 +265,7 @@ local function isLockableEntity( ent, skipParentCheck )
     local class = getClass( ent )
     if class == "prop_vehicle_prisoner_pod" and not skipParentCheck then -- Checks for parent vehicles like for example glide
         local parent = getParent( ent )
-        if parent == NULL then
+        if parent ~= NULL then
             if isLockableEntity( parent, true ) then
                 return false
             end

--- a/lua/glide/server/weaponry.lua
+++ b/lua/glide/server/weaponry.lua
@@ -3,6 +3,7 @@ local IsValid = IsValid
 local EntityMeta = FindMetaTable( "Entity" )
 local getClass = EntityMeta.GetClass
 local isVehicle = EntityMeta.IsVehicle
+local getParent = EntityMeta.GetParent
 
 function Glide.CreateTurret( vehicle, offset, angles )
     local turret = ents.Create( "glide_vehicle_turret" )
@@ -260,6 +261,30 @@ local WHITELIST = Glide.LOCKON_WHITELIST
 
 --- Finds all entities that we can lock on with `Glide.CanLockOnEntity`,
 --- then returns which one has the largest dot product between `normal` and the direction towards them.
+local function isLockableEntity( ent, skipParentCheck )
+    local class = getClass( ent )
+    if not skipParentCheck and class == "prop_vehicle_prisoner_pod" then
+        if isLockableEntity( getParent( ent ), true ) then -- Checks for parent vehicles like for example glide
+            return false
+        end
+        return true
+    end
+
+    if WHITELIST[class] then
+        return true
+    end
+
+    if isVehicle( ent ) then
+        return true
+    end
+
+    if ent.BaseClass and WHITELIST[ent.BaseClass.ClassName] then
+        return true
+    end
+
+    return false
+end
+
 function Glide.FindLockOnTarget( origin, normal, threshold, maxDistance, attacker, traceData, filter )
     local largestDot = 0
     local canLock, dot, target
@@ -274,9 +299,7 @@ function Glide.FindLockOnTarget( origin, normal, threshold, maxDistance, attacke
     end
 
     for _, e in AllEnts() do
-        if
-            e ~= attacker and not ignore[e] and ( WHITELIST[getClass( e )] or isVehicle( e ) or ( e.BaseClass and WHITELIST[e.BaseClass.ClassName] ) )
-        then
+        if e ~= attacker and not ignore[e] and isLockableEntity( e ) then
             canLock, dot = CanLockOnEntity( e, origin, normal, threshold, maxDistance, attacker, includeEmpty, traceData )
 
             if canLock and dot > largestDot then

--- a/lua/glide/server/weaponry.lua
+++ b/lua/glide/server/weaponry.lua
@@ -265,7 +265,7 @@ local function isLockableEntity( ent, skipParentCheck )
     local class = getClass( ent )
     if class == "prop_vehicle_prisoner_pod" and not skipParentCheck then -- Checks for parent vehicles like for example glide
         local parent = getParent( ent )
-        if IsValid( parent ) then
+        if parent == NULL then
             if isLockableEntity( parent, true ) then
                 return false
             end


### PR DESCRIPTION
Due to the addition of `prop_vehicle_prisoner_pod` glide now locks on glides own `prop_vehicle_prisoner_pod` causing missile targeting to swap back and forth between glide and its seats thus breaking lock.
I've made it so it checks the parent of a `prop_vehicle_prisoner_pod`, if it's a valid lock entity skip the entity and instead wait for the parent vehicle to be looped over.

If you prefer a different way of doing `isLockableEntity` feel free to edit it in my branch directly.