### PR TITLE
Wheel parameters refactor

### DIFF
--- a/lua/entities/base_glide/sv_wheels.lua
+++ b/lua/entities/base_glide/sv_wheels.lua
@@ -3,29 +3,6 @@ function ENT:WheelInit()
     self.wheelCount = 0
     self.wheelsEnabled = true
     self.steerAngle = Angle()
-
-    -- Store these values on a table that wheels can access.
-    self.wheelParams = self.wheelParams or {
-        -- Suspension
-        suspensionLength = 10,
-        springStrength = 800,
-        springDamper = 3000,
-
-        -- Wheel mass
-        inertia = 10,
-
-        -- Brake force
-        brakePower = 3000,
-
-        -- Forward traction
-        forwardTractionMax = 2600,
-
-        -- Side traction
-        sideTractionMultiplier = 20,
-        sideTractionMaxAng = 25,
-        sideTractionMax = 2400,
-        sideTractionMin = 800
-    }
 end
 
 function ENT:CreateWheel( offset, params )
@@ -74,7 +51,6 @@ end
 
 local Clamp = math.Clamp
 local ClampForce = Glide.ClampForce
-local SetupTraction = Glide.SetupTraction
 
 local linForce, angForce = Vector(), Vector()
 
@@ -95,12 +71,9 @@ function ENT:PhysicsSimulate( phys, dt )
     -- Do wheel physics
     if self.wheelCount > 0 and self.wheelsEnabled then
         local traceData = self.traceData
-        local params = self.wheelParams
-
-        SetupTraction( params )
 
         for _, w in ipairs( self.wheels ) do
-            w:DoPhysics( self, phys, params, traceData, linForce, angForce, dt )
+            w:DoPhysics( self, phys, traceData, linForce, angForce, dt )
         end
     end
 

--- a/lua/entities/base_glide/sv_wheels.lua
+++ b/lua/entities/base_glide/sv_wheels.lua
@@ -3,6 +3,11 @@ function ENT:WheelInit()
     self.wheelCount = 0
     self.wheelsEnabled = true
     self.steerAngle = Angle()
+
+    -- This was deprecated. Putting values here does nothing.
+    -- Wheel parameters are stored on each wheel now.
+    -- This will be removed in the future.
+    self.wheelParams = {}
 end
 
 function ENT:CreateWheel( offset, params )

--- a/lua/entities/base_glide_plane/init.lua
+++ b/lua/entities/base_glide_plane/init.lua
@@ -15,14 +15,6 @@ function ENT:OnPostInitialize()
     self.isGrounded = false
     self.brake = 0
     self.divePitch = 0
-
-    -- Update default wheel params
-    local params = self.wheelParams
-
-    params.brakePower = 800
-    params.suspensionLength = 10
-    params.springStrength = 1000
-    params.springDamper = 4000
 end
 
 --- Override this base class function.
@@ -34,6 +26,20 @@ function ENT:Repair()
         self.mainProp = self:CreatePropeller( self.PropOffset, self.PropRadius, self.PropModel, self.PropFastModel )
         self.mainProp:SetSpinAngle( math.random( 0, 180 ) )
     end
+end
+
+--- Override this base class function.
+function ENT:CreateWheel( offset, params )
+    -- Tweak default wheel params
+    params = params or {}
+
+    params.brakePower = params.brakePower or 800
+    params.suspensionLength = params.suspensionLength or 10
+    params.springStrength = params.springStrength or 1000
+    params.springDamper = params.springDamper or 4000
+
+    -- Let the base class create the wheel
+    return BaseClass.CreateWheel( self, offset, params )
 end
 
 --- Creates and stores a new propeller entity.
@@ -214,12 +220,15 @@ function ENT:OnPostThink( dt, selfTbl )
 
     local isGrounded = false
     local totalSideSlip = 0
+    local state
 
     for _, w in ipairs( self.wheels ) do
-        w.brake = self.brake
-        w.torque = torque
+        state = w.state
 
-        if w.isOnGround then
+        state.brake = self.brake
+        state.torque = torque
+
+        if state.isOnGround then
             isGrounded = true
             totalSideSlip = totalSideSlip + w:GetSideSlip()
         end

--- a/lua/entities/base_glide_tank/cl_init.lua
+++ b/lua/entities/base_glide_tank/cl_init.lua
@@ -90,21 +90,6 @@ function ENT:OnTurnOff()
 end
 
 --- Override this base class function.
-function ENT:ActivateMisc()
-    BaseClass.ActivateMisc( self )
-
-    local wheels = self.wheels
-    if not wheels then return end
-
-    -- Reduce the number of wheels playing sounds
-    for i, w in ipairs( wheels ) do
-        if i == 2 or i == 5 then
-            w.enableSounds = false
-        end
-    end
-end
-
---- Override this base class function.
 function ENT:DeactivateMisc()
     BaseClass.DeactivateMisc( self )
 

--- a/lua/entities/base_glide_tank/init.lua
+++ b/lua/entities/base_glide_tank/init.lua
@@ -19,20 +19,6 @@ function ENT:OnPostInitialize()
     self.isCannonInsideWall = false
     self.brake = 0.5
 
-    -- Update default wheel params
-    local params = self.wheelParams
-
-    params.brakePower = 15000
-    params.suspensionLength = 15
-    params.springStrength = 6000
-    params.springDamper = 30000
-
-    params.forwardTractionMax = 50000
-    params.sideTractionMultiplier = 800
-    params.sideTractionMinAng = 70
-    params.sideTractionMax = 12000
-    params.sideTractionMin = 10000
-
     self:SetEngineThrottle( 0 )
     self:SetEnginePower( 0 )
     self:SetTrackSpeed( 0 )
@@ -159,19 +145,39 @@ end
 
 --- Override this base class function.
 function ENT:CreateWheel( offset, params )
+    -- Tweak default wheel params
+    params = params or {}
+
+    params.brakePower = params.brakePower or 15000
+    params.suspensionLength = params.suspensionLength or 15
+    params.springStrength = params.springStrength or 6000
+    params.springDamper = params.springDamper or 30000
+
+    params.forwardTractionMax = params.forwardTractionMax or 50000
+    params.sideTractionMultiplier = params.sideTractionMultiplier or 800
+    params.sideTractionMinAng = params.sideTractionMinAng or 70
+    params.sideTractionMax = params.sideTractionMax or 12000
+    params.sideTractionMin = params.sideTractionMin or 10000
+
+    -- Let the base class create the wheel
     local wheel = BaseClass.CreateWheel( self, offset, params )
 
+    -- Check if the wheel is on the left side
     wheel.isLeftTrack = offset[2] > 0
 
     if wheel.isLeftTrack then
+        -- Count left side wheels
         self.wheelCountL = self.wheelCountL + 1
 
+        -- Don't play sounds for the second wheel on this side
         if self.wheelCountL == 2 then
             wheel:SetSoundsEnabled( false )
         end
     else
+        -- Count right side wheels
         self.wheelCountR = self.wheelCountR + 1
 
+        -- Don't play sounds for the second wheel on this side
         if self.wheelCountR == 2 then
             wheel:SetSoundsEnabled( false )
         end
@@ -237,25 +243,28 @@ function ENT:OnPostThink( dt, selfTbl )
         end
     end
 
+    -- Update wheel state
     local torqueL = selfTbl.availableTorqueL / selfTbl.wheelCountL
     local torqueR = selfTbl.availableTorqueR / selfTbl.wheelCountR
 
     local isGrounded = false
     local totalSideSlip = 0
     local totalAngVel = 0
+    local s
 
     for _, w in ipairs( self.wheels ) do
-        totalAngVel = totalAngVel + Abs( w.angularVelocity )
+        s = w.state
+        totalAngVel = totalAngVel + Abs( s.angularVelocity )
 
-        if w.isOnGround then
-            w.brake = selfTbl.brake
-            w.torque = w.isLeftTrack and torqueL or torqueR
+        if s.isOnGround then
+            s.brake = selfTbl.brake
+            s.torque = w.isLeftTrack and torqueL or torqueR
 
             isGrounded = true
             totalSideSlip = totalSideSlip + w:GetSideSlip()
         else
-            w.brake = 1
-            w.torque = 0
+            s.brake = 1
+            s.torque = 0
         end
     end
 

--- a/lua/entities/base_glide_tank/init.lua
+++ b/lua/entities/base_glide_tank/init.lua
@@ -167,13 +167,13 @@ function ENT:CreateWheel( offset, params )
         self.wheelCountL = self.wheelCountL + 1
 
         if self.wheelCountL == 2 then
-            wheel.enableSounds = false
+            wheel:SetSoundsEnabled( false )
         end
     else
         self.wheelCountR = self.wheelCountR + 1
 
         if self.wheelCountR == 2 then
-            wheel.enableSounds = false
+            wheel:SetSoundsEnabled( false )
         end
     end
 

--- a/lua/entities/glide_wheel/cl_init.lua
+++ b/lua/entities/glide_wheel/cl_init.lua
@@ -10,7 +10,6 @@ function ENT:Initialize()
 
     self.sounds = {}
     self.soundSurface = {}
-    self.enableSounds = true
 end
 
 function ENT:OnRemove()
@@ -32,7 +31,7 @@ end
 local Clamp = math.Clamp
 
 function ENT:ProcessSound( id, surfaceId, soundSet, altSurface, volume, pitch )
-    if not self.enableSounds then return end
+    if not self:GetSoundsEnabled() then return end
 
     local path = soundSet[surfaceId]
     local snd = self.sounds[id]

--- a/lua/entities/glide_wheel/init.lua
+++ b/lua/entities/glide_wheel/init.lua
@@ -41,6 +41,9 @@ function ENT:Initialize()
         -- Suspension length multiplier
         suspensionLengthMult = 1,
 
+        -- Forward traction multiplier
+        forwardTractionMult = 1,
+
         isOnGround = false,
         lastFraction = 1,
         lastSpringOffset = 0,
@@ -309,7 +312,7 @@ function ENT:DoPhysics( vehicle, phys, traceData, outLin, outAng, dt )
 
     -- Brake and torque forces
     surfaceGrip = SURFACE_GRIP[surfaceId] or 1
-    maxTraction = params.forwardTractionMax * surfaceGrip
+    maxTraction = params.forwardTractionMax * surfaceGrip * state.forwardTractionMult
 
     -- Grip loss logic
     brakeForce = Clamp( -velF, -state.brake, state.brake ) * params.brakePower * surfaceGrip
@@ -348,7 +351,7 @@ function ENT:DoPhysics( vehicle, phys, traceData, outLin, outAng, dt )
 
     -- Sideways traction ramp
     slipAngle = Abs( slipAngle * slipAngle )
-    maxTraction = TractionRamp( slipAngle, params.sideTractionMax, params.sideTractionMaxAng, params.sideTractionMin ) * surfaceGrip
+    maxTraction = TractionRamp( slipAngle, params.sideTractionMaxAng, params.sideTractionMax, params.sideTractionMin ) * surfaceGrip
     sideForce = -rt:Dot( vel * params.sideTractionMultiplier )
 
     -- Reduce sideways traction force as the wheel slips forward

--- a/lua/entities/glide_wheel/init.lua
+++ b/lua/entities/glide_wheel/init.lua
@@ -3,25 +3,52 @@ AddCSLuaFile( "cl_init.lua" )
 
 include( "shared.lua" )
 
-local EntityMeta = FindMetaTable( "Entity" )
-local getTable = EntityMeta.GetTable
-
 function ENT:Initialize()
     self:SetModel( "models/editor/axis_helper.mdl" )
     self:SetSolid( SOLID_NONE )
     self:SetMoveType( MOVETYPE_VPHYSICS )
 
-    self.torque = 0     -- Amount of torque to apply to the wheel
-    self.brake = 0      -- Amount of brake torque to apply to the wheel
-    self.spin = 0       -- Wheel spin angle around it's axle axis
+    self.params = {
+        -- Suspension
+        suspensionLength = 10,
+        springStrength = 800,
+        springDamper = 3000,
 
-    -- Traction multiplier, used for forward traction bias on cars
-    self.forwardTractionMult = 1
+        -- Brake force
+        brakePower = 3000,
 
-    self.isOnGround = false
-    self.lastFraction = 1
-    self.lastSpringOffset = 0
-    self.angularVelocity = 0
+        -- Forward traction
+        forwardTractionMax = 2600,
+
+        -- Side traction
+        sideTractionMultiplier = 20,
+        sideTractionMaxAng = 25,
+        sideTractionMax = 2400,
+        sideTractionMin = 800,
+
+        -- Other parameters
+        radius = 15,
+        basePos = Vector(),
+        steerMultiplier = 0,
+        enableAxleForces = false
+    }
+
+    self.state = {
+        torque = 0, -- Amount of torque to apply to the wheel
+        brake = 0,  -- Amount of brake torque to apply to the wheel
+        spin = 0,   -- Wheel spin angle around it's axle axis
+
+        isOnGround = false,
+        lastFraction = 1,
+        lastSpringOffset = 0,
+        angularVelocity = 0,
+
+        -- Used for raycasting, updates with wheel radius
+        traceMins = Vector(),
+        traceMaxs = Vector( 1, 1, 1 ),
+
+        isDebugging = GetConVar( "developer" ):GetBool()
+    }
 
     self.downSoundCD = 0
     self.upSoundCD = 0
@@ -31,56 +58,73 @@ function ENT:Initialize()
 end
 
 --- Set the size, models and steering properties to use on this wheel.
-function ENT:SetupWheel( params )
-    params = params or {}
+function ENT:SetupWheel( t )
+    t = t or {}
+
+    local params = self.params
+
+    -- Physical wheel radius, also affects the model scale
+    params.radius = t.radius or 15
 
     -- Wheel offset relative to the parent
-    self.basePos = params.basePos or self:GetLocalPos()
-    self.isOnRight = self.basePos[2] < 0
+    params.basePos = t.basePos or self:GetLocalPos()
 
     -- How much the parent's steering angle affects this wheel
-    self.steerMultiplier = params.steerMultiplier or 0
+    params.steerMultiplier = t.steerMultiplier or 0
 
-    -- Regular model
-    if params.model then
-        self.model = params.model
-        Glide.HideEntity( self, false )
+    -- Wheel model
+    if type( t.model ) == "string" then
+        params.model = t.model
     end
 
     -- Model rotation and scale
-    self.modelScale = params.modelScale or Vector( 0.3, 1, 1 )
-    self:SetModelAngle( params.modelAngle or Angle( 0, 0, 0 ) )
-    self:SetModelOffset( params.modelOffset or Vector( 0, 0, 0 ) )
+    params.modelScale = t.modelScale or Vector( 0.3, 1, 1 )
 
-    -- Default (not blown) radius of the wheel
-    self.defaultRadius = params.radius or 15
+    self:SetModelAngle( t.modelAngle or Angle( 0, 0, 0 ) )
+    self:SetModelOffset( t.modelOffset or Vector( 0, 0, 0 ) )
 
-    -- Should we apply forces at the axle position?
-    self.enableAxleForces = params.enableAxleForces or false
+    -- Should forces be applied at the axle position?
+    -- (Recommended for small vehicles like the Blazer)
+    params.enableAxleForces = t.enableAxleForces or false
 
+    -- Repair to update the model and radius
     self:Repair()
+
+    -- Suspension
+    params.suspensionLength = t.suspensionLength or params.suspensionLength
+    params.springStrength = t.springStrength or params.springStrength
+    params.springDamper = t.springDamper or params.springDamper
+
+    -- Brake force
+    params.brakePower = t.brakePower or params.brakePower
+
+    -- Forward traction
+    params.forwardTractionMax = t.forwardTractionMax or params.forwardTractionMax
+
+    -- Side traction
+    params.sideTractionMultiplier = t.sideTractionMultiplier or params.sideTractionMultiplier
+    params.sideTractionMaxAng = t.sideTractionMaxAng or params.sideTractionMaxAng
+    params.sideTractionMax = t.sideTractionMax or params.sideTractionMax
+    params.sideTractionMin = t.sideTractionMin or params.sideTractionMin
 end
 
 function ENT:Repair()
-    if self.modelOverride then
-        self:SetModel( self.modelOverride )
-
-    elseif self.model then
-        self:SetModel( self.model )
+    if self.params.model then
+        self:SetModel( self.params.model )
     end
 
     self:ChangeRadius()
 end
 
 function ENT:Blow()
-    self:ChangeRadius( self.defaultRadius * 0.8 )
+    self:ChangeRadius( self.params.radius * 0.8 )
     self:EmitSound( "glide/wheels/blowout.wav", 80, math.random( 95, 105 ), 1 )
 end
 
 function ENT:ChangeRadius( radius )
-    radius = radius or self.defaultRadius
+    radius = radius or self.params.radius
 
-    local size = self.modelScale * radius * 2
+    local size = self.params.modelScale * radius * 2
     local bounds = self:OBBMaxs() - self:OBBMins()
     local scale = Vector( size[1] / bounds[1], size[2] / bounds[2], size[3] / bounds[3] )
 
@@ -88,8 +132,8 @@ function ENT:ChangeRadius( radius )
     self:SetModelScale2( scale )
 
     -- Used on util.TraceHull
-    self.traceMins = Vector( radius * -0.2, radius * -0.2, 0 )
-    self.traceMaxs = Vector( radius * 0.2, radius * 0.2, 1 )
+    self.state.traceMins = Vector( radius * -0.2, radius * -0.2, 0 )
+    self.state.traceMaxs = Vector( radius * 0.2, radius * 0.2, 1 )
 end
 
 do
@@ -97,37 +141,42 @@ do
     local Approach = math.Approach
 
     function ENT:Update( vehicle, steerAngle, isAsleep, dt )
-        local selfTbl = getTable( self )
+        local state, params = self.state, self.params
+
         -- Get the wheel rotation relative to the vehicle, while applying the steering angle
-        local ang = vehicle:LocalToWorldAngles( steerAngle * selfTbl.steerMultiplier )
+        local ang = vehicle:LocalToWorldAngles( steerAngle * params.steerMultiplier )
 
         -- Rotate the wheel around the axle axis
-        selfTbl.spin = ( selfTbl.spin - Deg( selfTbl.angularVelocity ) * dt ) % 360
-        ang:RotateAroundAxis( ang:Right(), selfTbl.spin )
+        state.spin = ( state.spin - Deg( state.angularVelocity ) * dt ) % 360
+
+        ang:RotateAroundAxis( ang:Right(), state.spin )
         self:SetAngles( ang )
 
         if isAsleep then
             self:SetForwardSlip( 0 )
             self:SetSideSlip( 0 )
         else
-            self:SetLastSpin( selfTbl.spin )
-            self:SetLastOffset( self:GetLocalPos()[3] - selfTbl.basePos[3] )
+            self:SetLastSpin( state.spin )
+            self:SetLastOffset( self:GetLocalPos()[3] - params.basePos[3] )
         end
 
-        if isAsleep or not selfTbl.isOnGround then
-            selfTbl.angularVelocity = selfTbl.angularVelocity + ( selfTbl.torque / 20 ) * dt
-            selfTbl.angularVelocity = Approach( selfTbl.angularVelocity, 0, dt * 5 )
+        if isAsleep or not state.isOnGround then
+            -- Let the torque spin the wheel's fake mass
+            state.angularVelocity = state.angularVelocity + ( state.torque / 20 ) * dt
+
+            -- Slow down eventually
+            state.angularVelocity = Approach( state.angularVelocity, 0, dt * 4 )
         end
     end
 
     local TAU = math.pi * 2
 
     function ENT:GetRPM()
-        return self.angularVelocity * 60 / TAU
+        return self.state.angularVelocity * 60 / TAU
     end
 
     function ENT:SetRPM( rpm )
-        self.angularVelocity = rpm / ( 60 / TAU )
+        self.state.angularVelocity = rpm / ( 60 / TAU )
     end
 end
 
@@ -175,18 +224,20 @@ local TractionRamp = Glide.TractionRamp
 local pos, ang, fw, rt, up, radius, maxLen
 local ray, fraction, contactPos, surfaceId, vel, velF, velR, absVelR
 local offset, springForce, damperForce
-local brake, surfaceGrip, maxTraction, brakeForce, forwardForce, signForwardForce
+local surfaceGrip, maxTraction, brakeForce, forwardForce, signForwardForce
 local tractionCycle, gripLoss, groundAngularVelocity, angularVelocity = Vector()
 local slipAngle, sideForce
 local force, linearImp, angularImp
+local state, params
 
-function ENT:DoPhysics( vehicle, phys, params, traceData, outLin, outAng, dt )
-    local selfTbl = getTable( self )
+function ENT:DoPhysics( vehicle, phys, traceData, outLin, outAng, dt )
+    state, params = self.state, self.params
+
     -- Get the starting point of the raycast, where the suspension connects to the chassis
-    pos = phys:LocalToWorld( selfTbl.basePos )
+    pos = phys:LocalToWorld( params.basePos )
 
     -- Get the wheel rotation relative to the chassis, applying the steering angle if necessary
-    ang = vehicle:LocalToWorldAngles( vehicle.steerAngle * selfTbl.steerMultiplier )
+    ang = vehicle:LocalToWorldAngles( vehicle.steerAngle * params.steerMultiplier )
 
     -- Store some directions
     fw = ang:Forward()
@@ -199,8 +250,8 @@ function ENT:DoPhysics( vehicle, phys, params, traceData, outLin, outAng, dt )
 
     traceData.start = pos
     traceData.endpos = pos - up * maxLen
-    traceData.mins = selfTbl.traceMins
-    traceData.maxs = selfTbl.traceMaxs
+    traceData.mins = state.traceMins
+    traceData.maxs = state.traceMaxs
 
     ray = TraceHull( traceData )
     fraction = Clamp( ray.Fraction, radius / maxLen, 1 )
@@ -210,28 +261,27 @@ function ENT:DoPhysics( vehicle, phys, params, traceData, outLin, outAng, dt )
     surfaceId = ray.MatType or 0
     surfaceId = MAP_SURFACE_OVERRIDES[surfaceId] or surfaceId
 
-    --debugoverlay.Cross( pos, 10, 0.05, Color( 100, 100, 100 ), true )
-    --debugoverlay.Box( contactPos, self.traceMins, self.traceMaxs, 0.05, Color( 0, 200, 0 ) )
-
-    selfTbl.isOnGround = ray.Hit
+    state.isOnGround = ray.Hit
     self:SetContactSurface( surfaceId )
+
+    if state.isDebugging then
+        debugoverlay.Cross( pos, 10, 0.05, Color( 100, 100, 100 ), true )
+        debugoverlay.Box( contactPos, state.traceMins, state.traceMaxs, 0.05, Color( 0, 200, 0 ) )
+    end
 
     -- Update the wheel position and sounds
     self:SetLocalPos( phys:WorldToLocal( contactPos + up * radius ) )
-    self:DoSuspensionSounds( fraction - selfTbl.lastFraction, vehicle )
-    selfTbl.lastFraction = fraction
+    self:DoSuspensionSounds( fraction - state.lastFraction, vehicle )
+    state.lastFraction = fraction
 
     if not ray.Hit then
         self:SetForwardSlip( 0 )
         self:SetSideSlip( 0 )
 
-        -- Let the torque spin the wheel's fake mass
-        selfTbl.angularVelocity = selfTbl.angularVelocity + ( selfTbl.torque / 20 ) * dt
-
         return
     end
 
-    pos = self.enableAxleForces and pos or contactPos
+    pos = params.enableAxleForces and pos or contactPos
 
     -- Get the velocity at the wheel position
     vel = phys:GetVelocityAtPoint( pos )
@@ -244,22 +294,21 @@ function ENT:DoPhysics( vehicle, phys, params, traceData, outLin, outAng, dt )
     -- Suspension spring force & damping
     offset = maxLen - ( fraction * maxLen )
     springForce = ( offset * params.springStrength )
-    damperForce = ( selfTbl.lastSpringOffset - offset ) * params.springDamper
+    damperForce = ( state.lastSpringOffset - offset ) * params.springDamper
+    state.lastSpringOffset = offset
 
-    selfTbl.lastSpringOffset = offset
     force = ( springForce - damperForce ) * up:Dot( ray.HitNormal ) * ray.HitNormal
 
     -- Rolling resistance
-    force:Add( ( SURFACE_RESISTANCE[surfaceId] or 0.05 ) * fw * -velF )
+    force:Add( ( SURFACE_RESISTANCE[surfaceId] or 0.05 ) * -velF * fw )
 
     -- Brake and torque forces
-    brake = selfTbl.brake
     surfaceGrip = SURFACE_GRIP[surfaceId] or 1
-    maxTraction = params.forwardTractionMax * surfaceGrip * selfTbl.forwardTractionMult
+    maxTraction = params.forwardTractionMax * surfaceGrip
 
-    -- This grip loss logic was inspired by simfphys
-    brakeForce = Clamp( -velF, -brake, brake ) * params.brakePower * surfaceGrip
-    forwardForce = selfTbl.torque + brakeForce
+    -- Grip loss logic
+    brakeForce = Clamp( -velF, -state.brake, state.brake ) * params.brakePower * surfaceGrip
+    forwardForce = state.torque + brakeForce
     signForwardForce = forwardForce > 0 and 1 or ( forwardForce < 0 and -1 or 0 )
 
     -- Given an amount of sideways slippage (up to the max. traction)
@@ -277,24 +326,24 @@ function ENT:DoPhysics( vehicle, phys, params, traceData, outLin, outAng, dt )
     groundAngularVelocity = TAU * ( velF / ( radius * TAU ) )
 
     -- Add our grip loss to our spin velocity
-    angularVelocity = groundAngularVelocity + gripLoss * ( selfTbl.torque > 0 and 1 or ( selfTbl.torque < 0 and -1 or 0 ) )
+    angularVelocity = groundAngularVelocity + gripLoss * ( state.torque > 0 and 1 or ( state.torque < 0 and -1 or 0 ) )
 
     -- Smoothly match our current angular velocity to the angular velocity affected by grip loss
-    selfTbl.angularVelocity = Approach( selfTbl.angularVelocity, angularVelocity, dt * 200 )
+    state.angularVelocity = Approach( state.angularVelocity, angularVelocity, dt * 200 )
 
-    gripLoss = groundAngularVelocity - selfTbl.angularVelocity
+    gripLoss = groundAngularVelocity - state.angularVelocity
     self:SetForwardSlip( gripLoss )
 
     -- Calculate side slip angle
     slipAngle = ( Atan2( velR, Abs( velF ) ) / PI ) * 2
     self:SetSideSlip( slipAngle * Clamp( vehicle.totalSpeed * 0.005, 0, 1 ) * 2 )
-    slipAngle = Abs( slipAngle * slipAngle )
 
     -- Reduce sideways traction as the suspension spring applies less force
     surfaceGrip = surfaceGrip * Clamp( ( springForce * 0.5 ) / params.springStrength, 0, 1 )
 
     -- Sideways traction ramp
-    maxTraction = TractionRamp( slipAngle ) * surfaceGrip
+    slipAngle = Abs( slipAngle * slipAngle )
+    maxTraction = TractionRamp( slipAngle, params.sideTractionMax, params.sideTractionMaxAng, params.sideTractionMin ) * surfaceGrip
     sideForce = -rt:Dot( vel * params.sideTractionMultiplier )
 
     -- Reduce sideways traction force as the wheel slips forward

--- a/lua/entities/glide_wheel/init.lua
+++ b/lua/entities/glide_wheel/init.lua
@@ -52,7 +52,6 @@ function ENT:Initialize()
 
     self.downSoundCD = 0
     self.upSoundCD = 0
-    self.enableSounds = true
 
     self:SetupWheel()
 end
@@ -86,6 +85,9 @@ function ENT:SetupWheel( t )
     -- Should forces be applied at the axle position?
     -- (Recommended for small vehicles like the Blazer)
     params.enableAxleForces = t.enableAxleForces or false
+
+    -- Should this wheel play sounds?
+    self:SetSoundsEnabled( t.disableSounds ~= true )
 
     -- Repair to update the model and radius
     self:Repair()
@@ -188,7 +190,7 @@ do
     local PlaySoundSet = Glide.PlaySoundSet
 
     function ENT:DoSuspensionSounds( change, vehicle )
-        if not self.enableSounds then return end
+        if not self:GetSoundsEnabled() then return end
 
         local t = CurTime()
 

--- a/lua/entities/glide_wheel/init.lua
+++ b/lua/entities/glide_wheel/init.lua
@@ -38,6 +38,9 @@ function ENT:Initialize()
         brake = 0,  -- Amount of brake torque to apply to the wheel
         spin = 0,   -- Wheel spin angle around it's axle axis
 
+        -- Suspension length multiplier
+        suspensionLengthMult = 1,
+
         isOnGround = false,
         lastFraction = 1,
         lastSpringOffset = 0,
@@ -248,7 +251,7 @@ function ENT:DoPhysics( vehicle, phys, traceData, outLin, outAng, dt )
 
     -- Do the raycast
     radius = self:GetRadius()
-    maxLen = params.suspensionLength + radius
+    maxLen = state.suspensionLengthMult * params.suspensionLength + radius
 
     traceData.start = pos
     traceData.endpos = pos - up * maxLen

--- a/lua/entities/glide_wheel/shared.lua
+++ b/lua/entities/glide_wheel/shared.lua
@@ -23,4 +23,5 @@ function ENT:SetupDataTables()
     self:NetworkVar( "Float", "SideSlip" )
     self:NetworkVar( "Float", "ForwardSlip" )
     self:NetworkVar( "Int", "ContactSurface" )
+    self:NetworkVar( "Bool", "SoundsEnabled" )
 end

--- a/lua/entities/gtav_strikeforce.lua
+++ b/lua/entities/gtav_strikeforce.lua
@@ -206,20 +206,22 @@ if SERVER then
     function ENT:CreateFeatures()
         self:CreateSeat( Vector( 157, 0, 4 ), Angle( 0, 270, 10 ), Vector( -160, 120, 0 ), true )
 
-        -- Update default wheel params
-        self.wheelParams.suspensionLength = 38
-        self.wheelParams.springStrength = 1500
-        self.wheelParams.springDamper = 6000
-        self.wheelParams.brakePower = 2000
-        self.wheelParams.sideTractionMultiplier = 250
+        local wheelParams = {
+            suspensionLength = 38,
+            springStrength = 1500,
+            springDamper = 6000,
+            brakePower = 2000,
+            sideTractionMultiplier = 250
+        }
 
         -- Front
-        self:CreateWheel( Vector( 180, -12, -25 ), {
-            steerMultiplier = 1
-        } )
+        wheelParams.steerMultiplier = 1
+        self:CreateWheel( Vector( 180, -12, -25 ), wheelParams )
 
-        self:CreateWheel( Vector( -13, 85, -25 ) ) -- Rear left
-        self:CreateWheel( Vector( -13, -85, -25 ) ) -- Rear right
+        -- Rear
+        wheelParams.steerMultiplier = 0
+        self:CreateWheel( Vector( -13, 85, -25 ), wheelParams ) -- left
+        self:CreateWheel( Vector( -13, -85, -25 ), wheelParams ) -- right
 
         self:ChangeWheelRadius( 12 )
 

--- a/lua/glide/server/util.lua
+++ b/lua/glide/server/util.lua
@@ -101,7 +101,7 @@ do
     -- Sideways traction logic
     local x
 
-    function Glide.TractionRamp( slipAngle, sideTractionMax, sideTractionMaxAng, sideTractionMin )
+    function Glide.TractionRamp( slipAngle, sideTractionMaxAng, sideTractionMax, sideTractionMin )
         sideTractionMaxAng = sideTractionMaxAng / 90 -- Convert max slip angle to the 0-1 range
         x = ( slipAngle - sideTractionMaxAng ) / ( 1 - sideTractionMaxAng )
 

--- a/lua/glide/server/util.lua
+++ b/lua/glide/server/util.lua
@@ -98,16 +98,14 @@ do
 end
 
 do
-    -- Traction logic
-    local ay, bx, by, xx = 0, 0, 0, 0
+    -- Sideways traction logic
+    local x
 
-    function Glide.SetupTraction( t )
-        ay, bx, by = t.sideTractionMax, t.sideTractionMaxAng / 90, t.sideTractionMin
-    end
+    function Glide.TractionRamp( slipAngle, sideTractionMax, sideTractionMaxAng, sideTractionMin )
+        sideTractionMaxAng = sideTractionMaxAng / 90 -- Convert max slip angle to the 0-1 range
+        x = ( slipAngle - sideTractionMaxAng ) / ( 1 - sideTractionMaxAng )
 
-    function Glide.TractionRamp( x )
-        xx = ( x - bx ) / ( 1 - bx )
-        return x < bx and ay or ( ay * ( 1 - xx ) ) + ( by * xx )
+        return slipAngle < sideTractionMaxAng and sideTractionMax or ( sideTractionMax * ( 1 - x ) ) + ( sideTractionMin * x )
     end
 end
 

--- a/lua/weapons/gmod_tool/stools/glide_wheel_model.lua
+++ b/lua/weapons/gmod_tool/stools/glide_wheel_model.lua
@@ -78,12 +78,12 @@ if SERVER then
 
         for _, w in ipairs( wheels ) do
             if not w.GlideIsHidden then
-                w.modelOverride = model
+                w.model = model
                 w.modelScale = scale
                 w:SetModel( model )
                 w:ChangeRadius()
 
-                if w.isOnRight then
+                if w.params.basePos[2] < 0 then
                     w:SetModelOffset( -offset )
                     w:SetModelAngle( angle + Angle( 0, 180, 0 ) )
                 else


### PR DESCRIPTION
## Advantages

- Allows changing wheel properties (like `suspensionLength`, `springStrength`, `sideTractionMultiplier`, etc) per wheel instead of per vehicle
- On cars, functions like `self:SetSuspensionLength`, `self:SetSpringStrength` and `self:SetSideTractionMultiplier` will still affect all wheels

## Breaking changes

### TL;DR

Do not do this:

```lua
function ENT:CreateFeatures()
    self.wheelParams.suspensionLength = 28

    self:CreateWheel( Vector( 143, 0, -21 ) )
    self:CreateWheel( Vector( -58, 64, -20 ) )
    self:CreateWheel( Vector( -58, -64, -20 ) )
end
```

Do this:

```lua
function ENT:CreateFeatures()
    local wheelParams = { suspensionLength = 28 }

    self:CreateWheel( Vector( 143, 0, -21 ), wheelParams )
    self:CreateWheel( Vector( -58, 64, -20 ), wheelParams )
    self:CreateWheel( Vector( -58, -64, -20 ), wheelParams )
end
```

### Specifics

- Values that used to go in `vehicle.wheelParams` now goes to table given to `self:CreateWheel` instead
- These same values are stored in the `wheel.params` table now
- `vehicle.wheelParams` will still exist to prevent errors, but it's values won't do anything anymore
- `wheel.torque`, `wheel.brake`, `wheel.isOnGround` and other frequently changed variables are stored on `wheel.state` now
- When creating wheels, aircraft will already apply brakes by default
- Given the two changes mentioned above, on helicopters with landing gear, **don't do this** after creating wheels:

```lua
for _, w in ipairs( self.wheels ) do
    w.brake = 0.5
end
```