### PR TITLE
Tweak damage values

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ A pack of content and entity classes to add cars, motorcycles, planes, helicopte
 
 | Command | Description
 | --------------------------------- | ------
-| `glide_damage_multiplier_bullet` `<number>` | Damage multiplier for bullets hitting Glide vehicles
-| `glide_damage_multiplier_blast` `<number>` | Damage multiplier for explosions hitting Glide vehicles
-| `glide_damage_multiplier_collision` `<number>` | Damage multiplier taken by Glide vehicles after colliding against other things
+| `glide_bullet_damage_multiplier` `<number>` | Damage multiplier for bullets hitting Glide vehicles
+| `glide_blast_damage_multiplier` `<number>` | Damage multiplier for explosions hitting Glide vehicles
+| `glide_physics_damage_multiplier` `<number>` | Damage multiplier taken by Glide vehicles after colliding against other things
 
 ### Sandbox limits
 

--- a/lua/autorun/sh_glide.lua
+++ b/lua/autorun/sh_glide.lua
@@ -157,9 +157,9 @@ end
 
 if SERVER then
     -- Damage multiplier convars
-    CreateConVar( "glide_damage_multiplier_bullet", "0.75", FCVAR_ARCHIVE + FCVAR_NOTIFY, "Damage multiplier for bullets hitting Glide vehicles.", 0, 10 )
-    CreateConVar( "glide_damage_multiplier_blast", "5", FCVAR_ARCHIVE + FCVAR_NOTIFY, "Damage multiplier for explosions hitting Glide vehicles.", 0, 10 )
-    CreateConVar( "glide_damage_multiplier_collision", "1", FCVAR_ARCHIVE + FCVAR_NOTIFY, "Damage multiplier taken by Glide vehicles after colliding against other things.", 0, 10 )
+    CreateConVar( "glide_bullet_damage_multiplier", "1", FCVAR_ARCHIVE + FCVAR_NOTIFY, "Damage multiplier for bullets hitting Glide vehicles.", 0, 10 )
+    CreateConVar( "glide_blast_damage_multiplier", "1", FCVAR_ARCHIVE + FCVAR_NOTIFY, "Damage multiplier for explosions hitting Glide vehicles.", 0, 10 )
+    CreateConVar( "glide_physics_damage_multiplier", "1", FCVAR_ARCHIVE + FCVAR_NOTIFY, "Damage multiplier taken by Glide vehicles after colliding against other things.", 0, 10 )
 end
 
 -- Sandbox limits

--- a/lua/entities/base_glide/init.lua
+++ b/lua/entities/base_glide/init.lua
@@ -483,7 +483,7 @@ function ENT:Think()
             local inflictor = IsValid( self.lastDamageInflictor ) and self.lastDamageInflictor or self
 
             local dmg = DamageInfo()
-            dmg:SetDamage( self.ChassisFireDamage * dt )
+            dmg:SetDamage( self.MaxChassisHealth * self.ChassisFireDamageMultiplier * dt )
             dmg:SetAttacker( attacker )
             dmg:SetInflictor( inflictor )
             dmg:SetDamageType( 0 )

--- a/lua/entities/base_glide/init.lua
+++ b/lua/entities/base_glide/init.lua
@@ -483,7 +483,7 @@ function ENT:Think()
             local inflictor = IsValid( self.lastDamageInflictor ) and self.lastDamageInflictor or self
 
             local dmg = DamageInfo()
-            dmg:SetDamage( 10 * dt )
+            dmg:SetDamage( self.ChassisFireDamage * dt )
             dmg:SetAttacker( attacker )
             dmg:SetInflictor( inflictor )
             dmg:SetDamageType( 0 )

--- a/lua/entities/base_glide/shared.lua
+++ b/lua/entities/base_glide/shared.lua
@@ -160,7 +160,7 @@ if SERVER then
     ENT.CollisionDamageMultiplier = 0.5
 
     -- How much of the chassis damage is also applied to the engine?
-    ENT.EngineDamageMultiplier = 0.0013
+    ENT.EngineDamageMultiplier = 1.2
 
     -- How much of the blast damage force should be applied to the vehicle?
     ENT.BlastForceMultiplier = 0.01

--- a/lua/entities/base_glide/shared.lua
+++ b/lua/entities/base_glide/shared.lua
@@ -165,8 +165,8 @@ if SERVER then
     -- How much of the blast damage force should be applied to the vehicle?
     ENT.BlastForceMultiplier = 0.01
 
-    -- How much damage per tick does engine fire deal to the chassis?
-    ENT.ChassisFireDamage = 5
+    -- Damage multiplier for engine fire
+    ENT.ChassisFireDamageMultiplier = 0.01
 
     -- Given a dot product between the vehicle's forward direction
     -- and the direction to a lock-on target, how large must that dot product be

--- a/lua/entities/base_glide/shared.lua
+++ b/lua/entities/base_glide/shared.lua
@@ -155,15 +155,21 @@ if SERVER then
     ENT.SpawnAngleOffset = Angle( 0, 90, 0 )
 
     -- Multiply damage taken by these values
-    ENT.BulletDamageMultiplier = 0.75
-    ENT.BlastDamageMultiplier = 1
-    ENT.CollisionDamageMultiplier = 1
+    ENT.BulletDamageMultiplier = 1.5
+    ENT.BlastDamageMultiplier = 5
+    ENT.CollisionDamageMultiplier = 0.5
 
     -- How much of the chassis damage is also applied to the engine?
-    ENT.EngineDamageMultiplier = 0.001
+    ENT.EngineDamageMultiplier = 0.0013
 
     -- How much of the blast damage force should be applied to the vehicle?
     ENT.BlastForceMultiplier = 0.01
+
+    -- If the chassis health drops below this, set the engine on fire
+    ENT.ChassisMinHealth = 150
+
+    -- How much damage per tick does engine fire deal to the chassis?
+    ENT.ChassisFireDamage = 5
 
     -- Given a dot product between the vehicle's forward direction
     -- and the direction to a lock-on target, how large must that dot product be

--- a/lua/entities/base_glide/shared.lua
+++ b/lua/entities/base_glide/shared.lua
@@ -165,9 +165,6 @@ if SERVER then
     -- How much of the blast damage force should be applied to the vehicle?
     ENT.BlastForceMultiplier = 0.01
 
-    -- If the chassis health drops below this, set the engine on fire
-    ENT.ChassisMinHealth = 150
-
     -- How much damage per tick does engine fire deal to the chassis?
     ENT.ChassisFireDamage = 5
 

--- a/lua/entities/base_glide/sv_damage.lua
+++ b/lua/entities/base_glide/sv_damage.lua
@@ -116,13 +116,13 @@ function ENT:OnTakeDamage( dmginfo )
     health = health - amount
 
     self:SetChassisHealth( health )
-    self:TakeEngineDamage( amount * self.EngineDamageMultiplier )
+    self:TakeEngineDamage( ( amount / self.MaxChassisHealth ) * self.EngineDamageMultiplier )
     self:UpdateHealthOutputs()
 
     self.lastDamageAttacker = dmginfo:GetAttacker()
     self.lastDamageInflictor = dmginfo:GetInflictor()
 
-    if health / self.MaxChassisHealth < 0.2 and self:WaterLevel() < 3 then
+    if health / self.MaxChassisHealth < 0.18 and self:WaterLevel() < 3 then
         self:SetIsEngineOnFire( true )
     end
 

--- a/lua/entities/base_glide/sv_damage.lua
+++ b/lua/entities/base_glide/sv_damage.lua
@@ -88,8 +88,8 @@ end
 
 local IsValid = IsValid
 
-local cvarBullet = GetConVar( "glide_damage_multiplier_bullet" )
-local cvarBlast = GetConVar( "glide_damage_multiplier_blast" )
+local cvarBullet = GetConVar( "glide_bullet_damage_multiplier" )
+local cvarBlast = GetConVar( "glide_blast_damage_multiplier" )
 
 function ENT:OnTakeDamage( dmginfo )
     if self.hasExploded then return end
@@ -138,7 +138,7 @@ local Clamp = math.Clamp
 local RandomInt = math.random
 local PlaySoundSet = Glide.PlaySoundSet
 
-local cvarCollision = GetConVar( "glide_damage_multiplier_collision" )
+local cvarCollision = GetConVar( "glide_physics_damage_multiplier" )
 
 function ENT:PhysicsCollide( data )
     if data.TheirSurfaceProps == 76 then -- default_silent

--- a/lua/entities/base_glide/sv_damage.lua
+++ b/lua/entities/base_glide/sv_damage.lua
@@ -122,7 +122,7 @@ function ENT:OnTakeDamage( dmginfo )
     self.lastDamageAttacker = dmginfo:GetAttacker()
     self.lastDamageInflictor = dmginfo:GetInflictor()
 
-    if health < 250 and self:WaterLevel() < 3 then
+    if health < self.ChassisMinHealth and self:WaterLevel() < 3 then
         self:SetIsEngineOnFire( true )
     end
 

--- a/lua/entities/base_glide/sv_damage.lua
+++ b/lua/entities/base_glide/sv_damage.lua
@@ -122,7 +122,7 @@ function ENT:OnTakeDamage( dmginfo )
     self.lastDamageAttacker = dmginfo:GetAttacker()
     self.lastDamageInflictor = dmginfo:GetInflictor()
 
-    if health < self.ChassisMinHealth and self:WaterLevel() < 3 then
+    if health / self.MaxChassisHealth < 0.2 and self:WaterLevel() < 3 then
         self:SetIsEngineOnFire( true )
     end
 

--- a/lua/entities/base_glide_aircraft/shared.lua
+++ b/lua/entities/base_glide_aircraft/shared.lua
@@ -7,9 +7,6 @@ ENT.AdminOnly = false
 ENT.AutomaticFrameAdvance = true
 ENT.VJTag_ID_Aircraft = true
 
--- Increase default max. chassis health
-ENT.MaxChassisHealth = 1200
-
 DEFINE_BASECLASS( "base_glide" )
 
 --- Override this base class function.
@@ -58,6 +55,8 @@ if SERVER then
     ENT.IsHeavyVehicle = true
     ENT.ExplosionRadius = 700
     ENT.SuspensionHeavySound = "Glide.Suspension.CompressBike"
+
+    ENT.CollisionDamageMultiplier = 4
 
     -- Damaged engine sound
     ENT.DamagedEngineSound = "Glide.Damaged.GearGrind"

--- a/lua/entities/base_glide_car/shared.lua
+++ b/lua/entities/base_glide_car/shared.lua
@@ -9,9 +9,6 @@ ENT.Editable = true
 -- Change vehicle type
 ENT.VehicleType = Glide.VEHICLE_TYPE.CAR
 
--- Decrease default max. chassis health
-ENT.MaxChassisHealth = 900
-
 -- Should we prevent players from editing these NW variables?
 ENT.UneditableNWVars = {}
 
@@ -188,9 +185,7 @@ if CLIENT then
 end
 
 if SERVER then
-    ENT.EngineDamageMultiplier = 0.0016
     ENT.CollisionParticleSize = 0.9
-    ENT.CollisionDamageMultiplier = 0.5
     ENT.AngularDrag = Vector( -0.5, -0.5, -4 ) -- Roll, pitch, yaw
 
     -- How long does it take for the vehicle to start up?

--- a/lua/entities/base_glide_heli/shared.lua
+++ b/lua/entities/base_glide_heli/shared.lua
@@ -67,7 +67,7 @@ if CLIENT then
 end
 
 if SERVER then
-    ENT.CollisionDamageMultiplier = 2
+    ENT.CollisionDamageMultiplier = 3
     ENT.AngularDrag = Vector( -10, -18, -10 ) -- Roll, pitch, yaw
 
     -- How far can the rotor's blades hit things

--- a/lua/entities/base_glide_plane/shared.lua
+++ b/lua/entities/base_glide_plane/shared.lua
@@ -72,7 +72,6 @@ if CLIENT then
 end
 
 if SERVER then
-    ENT.CollisionDamageMultiplier = 4.5
     ENT.AngularDrag = Vector( -2, -2, -10 ) -- Roll, pitch, yaw
     ENT.DamagedEngineSound = "Glide.Damaged.AircraftEngineBreakdown"
     ENT.DamagedEngineVolume = 1.0

--- a/lua/entities/base_glide_tank/init.lua
+++ b/lua/entities/base_glide_tank/init.lua
@@ -121,7 +121,9 @@ function ENT:OnWeaponFire( weapon )
     local dir = aimPos - projectilePos
     dir:Normalize()
 
-    Glide.FireProjectile( projectilePos, dir:Angle(), self:GetDriver(), self )
+    local projectile = Glide.FireProjectile( projectilePos, dir:Angle(), self:GetDriver(), self )
+    projectile.damage = self.TurretDamage
+
     self:EmitSound( self.TurretFireSound, 100, math.random( 95, 105 ), self.TurretFireVolume )
 
     local eff = EffectData()

--- a/lua/entities/base_glide_tank/shared.lua
+++ b/lua/entities/base_glide_tank/shared.lua
@@ -9,8 +9,8 @@ ENT.AutomaticFrameAdvance = true
 -- Change vehicle type
 ENT.VehicleType = Glide.VEHICLE_TYPE.TANK
 
--- Increase default max. chassis health
-ENT.MaxChassisHealth = 3000
+-- Tweak max. chassis health
+ENT.MaxChassisHealth = 6000
 
 -- Turrets are predictable, so their properties
 -- should be set both on SERVER and CLIENT.
@@ -110,12 +110,13 @@ end
 if SERVER then
     ENT.IsHeavyVehicle = true
     ENT.ChassisMass = 20000
+    ENT.ChassisMinHealth = 600
+    ENT.ChassisFireDamage = 50
 
-    ENT.BulletDamageMultiplier = 0.25
-    ENT.BlastDamageMultiplier = 1
-    ENT.CollisionDamageMultiplier = 0.8
-    ENT.EngineDamageMultiplier = 0.00035
+    ENT.BlastDamageMultiplier = 3
     ENT.BlastForceMultiplier = 0.005
+    ENT.CollisionDamageMultiplier = 3
+    ENT.EngineDamageMultiplier = 0.0002
 
     ENT.SuspensionHeavySound = "Glide.Suspension.CompressTruck"
     ENT.SuspensionDownSound = "Glide.Suspension.Stress"
@@ -131,6 +132,7 @@ if SERVER then
     ENT.TurretFireSound = ")glide/tanks/acf_fire4.mp3"
     ENT.TurretFireVolume = 0.8
     ENT.TurretRecoilForce = 50
+    ENT.TurretDamage = 550
 
     -- How much torque to distribute among all wheels?
     ENT.EngineTorque = 40000

--- a/lua/entities/base_glide_tank/shared.lua
+++ b/lua/entities/base_glide_tank/shared.lua
@@ -110,7 +110,6 @@ end
 if SERVER then
     ENT.IsHeavyVehicle = true
     ENT.ChassisMass = 20000
-    ENT.ChassisFireDamage = 50
 
     ENT.BlastDamageMultiplier = 3
     ENT.BlastForceMultiplier = 0.005

--- a/lua/entities/base_glide_tank/shared.lua
+++ b/lua/entities/base_glide_tank/shared.lua
@@ -110,13 +110,11 @@ end
 if SERVER then
     ENT.IsHeavyVehicle = true
     ENT.ChassisMass = 20000
-    ENT.ChassisMinHealth = 600
     ENT.ChassisFireDamage = 50
 
     ENT.BlastDamageMultiplier = 3
     ENT.BlastForceMultiplier = 0.005
     ENT.CollisionDamageMultiplier = 3
-    ENT.EngineDamageMultiplier = 0.0002
 
     ENT.SuspensionHeavySound = "Glide.Suspension.CompressTruck"
     ENT.SuspensionDownSound = "Glide.Suspension.Stress"

--- a/lua/entities/gtav_insurgent.lua
+++ b/lua/entities/gtav_insurgent.lua
@@ -7,7 +7,7 @@ ENT.PrintName = "Insurgent Pick-up"
 
 ENT.GlideCategory = "Default"
 ENT.ChassisModel = "models/gta5/vehicles/insurgent/chassis.mdl"
-ENT.MaxChassisHealth = 1500
+ENT.MaxChassisHealth = 2000
 
 DEFINE_BASECLASS( "base_glide_car" )
 
@@ -172,6 +172,8 @@ end
 if SERVER then
     ENT.SpawnPositionOffset = Vector( 0, 0, 45 )
     ENT.ChassisMass = 2000
+    ENT.EngineDamageMultiplier = 0.0006
+
     ENT.FallOnCollision = true
     ENT.BurnoutForce = 30
     ENT.AirControlForce = Vector( 0.3, 0.2, 0.2 )

--- a/lua/entities/gtav_insurgent.lua
+++ b/lua/entities/gtav_insurgent.lua
@@ -172,7 +172,6 @@ end
 if SERVER then
     ENT.SpawnPositionOffset = Vector( 0, 0, 45 )
     ENT.ChassisMass = 2000
-    ENT.EngineDamageMultiplier = 0.0006
 
     ENT.FallOnCollision = true
     ENT.BurnoutForce = 30

--- a/lua/entities/gtav_strikeforce.lua
+++ b/lua/entities/gtav_strikeforce.lua
@@ -7,7 +7,7 @@ ENT.PrintName = "B-11 Strikeforce"
 
 ENT.GlideCategory = "Default"
 ENT.ChassisModel = "models/gta5/vehicles/strikeforce/chassis.mdl"
-ENT.MaxChassisHealth = 1500
+ENT.MaxChassisHealth = 1800
 
 ENT.PropOffset = Vector( 114, 0, 3 )
 
@@ -166,7 +166,6 @@ end
 if SERVER then
     ENT.ChassisMass = 1500
     ENT.SpawnPositionOffset = Vector( 0, 0, 40 )
-    ENT.CollisionDamageMultiplier = 5
 
     ENT.ExplosionGibs = {
         "models/gta5/vehicles/strikeforce/gibs/chassis.mdl",


### PR DESCRIPTION
- Renamed ConVar `glide_damage_multiplier_bullet` to `glide_bullet_damage_multiplier`, default value is `1` now
- Renamed ConVar `glide_damage_multiplier_blast` to `glide_blast_damage_multiplier`, default value is `1` now
- Renamed ConVar `glide_damage_multiplier_collision` to `glide_physics_damage_multiplier`, default value is `1` now
- Tweaked default health and damage values to account for the new convar values
- Tweaked tank health and turret damage values to be a bit more competitive against Simfphys tanks
- Scale the threshold needed to start a engine fire depending the max. chassis health
- Scale how much damage the engine fire does depending on the max. chassis health
- Scale damage converted from the chassis to the engine depending on the max. chassis health

All in all, these last 3 items on the list makes so you don't have to tweak some damage parameters when you increase/decrease the max. chassis health of your vehicle.

For example, you don't have to tweak `ENT.EngineDamageMultiplier` just to make sure the engine won't die while the chassis still has plenty of health.
