### PR TITLE
Add `HeadlightColor` network variable

### DIFF
--- a/lua/autorun/sh_glide.lua
+++ b/lua/autorun/sh_glide.lua
@@ -48,6 +48,9 @@ Glide.MOUSE_FLY_MODE = {
     CAMERA = 2      -- Free camera
 }
 
+-- Default color for headlights
+Glide.DEFAULT_HEADLIGHT_COLOR = Color( 255, 231, 176 )
+
 if SERVER then
     -- Surface grip multipliers for wheels
     Glide.SURFACE_GRIP = {
@@ -71,9 +74,6 @@ if SERVER then
 end
 
 if CLIENT then
-    -- Default color for headlights
-    Glide.DEFAULT_HEADLIGHT_COLOR = Color( 255, 221, 141 )
-
     -- Vehicle camera types
     Glide.CAMERA_TYPE = {
         CAR = 0,

--- a/lua/entities/base_glide_car/cl_init.lua
+++ b/lua/entities/base_glide_car/cl_init.lua
@@ -26,6 +26,10 @@ function ENT:OnGearChange( _, _, gear )
     end
 end
 
+function ENT:OnHeadlightColorChange()
+    self.headlightState = 0 -- Let OnUpdateMisc recreate the lights
+end
+
 --- Override this base class function.
 function ENT:OnEngineStateChange( _, lastState, state )
     if state == 1 then
@@ -250,6 +254,7 @@ local DrawLightSprite = Glide.DrawLightSprite
 
 local COLOR_BRAKE = Color( 255, 0, 0, 255 )
 local COLOR_REV = Color( 255, 255, 255, 200 )
+local COLOR_HEADLIGHT = Color( 255, 255, 255 )
 
 --- Implement this base class function.
 function ENT:OnUpdateMisc()
@@ -265,6 +270,13 @@ function ENT:OnUpdateMisc()
     local headlightState = self:GetHeadlightState()
     local isHeadlightOn = headlightState > 0
 
+    if isHeadlightOn then
+        local colorVec = self:GetHeadlightColor()
+        COLOR_HEADLIGHT.r = colorVec[1] * 255
+        COLOR_HEADLIGHT.g = colorVec[2] * 255
+        COLOR_HEADLIGHT.b = colorVec[3] * 255
+    end
+
     -- Render lights and sprites
     local myPos = self:GetPos()
     local pos, dir
@@ -274,7 +286,7 @@ function ENT:OnUpdateMisc()
         dir = self:LocalToWorld( l.dir ) - myPos
 
         if isHeadlightOn and l.type == "headlight" then
-            DrawLightSprite( pos, dir, l.size or 30, l.color or COLOR_REV, true )
+            DrawLightSprite( pos, dir, l.size or 30, COLOR_HEADLIGHT, true )
 
         elseif isBraking and l.type == "brake" then
             DrawLightSprite( pos, dir, l.size or 30, COLOR_BRAKE, true )
@@ -311,7 +323,7 @@ function ENT:OnUpdateMisc()
 
         for _, v in ipairs( self.Headlights ) do
             v.angles = v.angles or Angle( 10, 0, 0 )
-            self:CreateHeadlight( v.offset, v.angles, v.color )
+            self:CreateHeadlight( v.offset, v.angles, COLOR_HEADLIGHT )
         end
     end
 

--- a/lua/entities/base_glide_car/init.lua
+++ b/lua/entities/base_glide_car/init.lua
@@ -29,6 +29,9 @@ function ENT:OnPostInitialize()
     self:SetHeadlightState( 0 )
     self:SetGear( 0 )
 
+    local headlightColor = Glide.DEFAULT_HEADLIGHT_COLOR
+    self:SetHeadlightColor( Vector( headlightColor.r / 255, headlightColor.g / 255, headlightColor.b / 255 ) )
+
     self:SetSteering( 0 )
     self:SetEngineRPM( 0 )
     self:SetEngineThrottle( 0 )

--- a/lua/entities/base_glide_car/shared.lua
+++ b/lua/entities/base_glide_car/shared.lua
@@ -40,7 +40,8 @@ function ENT:SetupDataTables()
     self:NetworkVar( "Float", "EngineRPM" )
     self:NetworkVar( "Float", "EngineThrottle" )
 
-    -- Wheel and suspension properties, allow editing with the C menu.
+    -- All DT variables below are editable properties
+    self:NetworkVar( "Vector", "HeadlightColor", { KeyName = "HeadlightColor", Edit = { type = "VectorColor", order = 0, category = "#glide.settings" } } )
     self:NetworkVar( "Vector", "TireSmokeColor", { KeyName = "TireSmokeColor", Edit = { type = "VectorColor", order = 0, category = "#glide.editvar.wheels" } } )
 
     local order = 0
@@ -113,6 +114,9 @@ function ENT:SetupDataTables()
     if CLIENT then
         -- Callback used to play gear change sounds
         self:NetworkVarNotify( "Gear", self.OnGearChange )
+
+        -- Callback used to update the light color
+        self:NetworkVarNotify( "HeadlightColor", self.OnHeadlightColorChange )
     end
 end
 

--- a/lua/entities/gtav_airbus.lua
+++ b/lua/entities/gtav_airbus.lua
@@ -34,8 +34,8 @@ if CLIENT then
     }
 
     ENT.Headlights = {
-        { offset = Vector( 292, 30, -10 ), color = Glide.DEFAULT_HEADLIGHT_COLOR },
-        { offset = Vector( 292, -30, -10 ), color = Glide.DEFAULT_HEADLIGHT_COLOR }
+        { offset = Vector( 292, 30, -10 ) },
+        { offset = Vector( 292, -30, -10 ) }
     }
 
     ENT.LightSprites = {
@@ -43,10 +43,10 @@ if CLIENT then
         { type = "brake", offset = Vector( -293, -41, 10.5 ), dir = Vector( -1, 0, 0 ) },
         { type = "reverse", offset = Vector( -293, 36, 10.5 ), dir = Vector( -1, 0, 0 ) },
         { type = "reverse", offset = Vector( -293, -36, 10.5 ), dir = Vector( -1, 0, 0 ) },
-        { type = "headlight", offset = Vector( 290, 41.5, -11 ), dir = Vector( 1, 0, 0 ), color = Glide.DEFAULT_HEADLIGHT_COLOR },
-        { type = "headlight", offset = Vector( 290, -41.5, -11 ), dir = Vector( 1, 0, 0 ), color = Glide.DEFAULT_HEADLIGHT_COLOR },
-        { type = "headlight", offset = Vector( 290, 31, -11 ), dir = Vector( 1, 0, 0 ), color = Glide.DEFAULT_HEADLIGHT_COLOR },
-        { type = "headlight", offset = Vector( 290, -31, -11 ), dir = Vector( 1, 0, 0 ), color = Glide.DEFAULT_HEADLIGHT_COLOR }
+        { type = "headlight", offset = Vector( 290, 41.5, -11 ), dir = Vector( 1, 0, 0 ) },
+        { type = "headlight", offset = Vector( 290, -41.5, -11 ), dir = Vector( 1, 0, 0 ) },
+        { type = "headlight", offset = Vector( 290, 31, -11 ), dir = Vector( 1, 0, 0 ) },
+        { type = "headlight", offset = Vector( 290, -31, -11 ), dir = Vector( 1, 0, 0 ) }
     }
 
     function ENT:OnCreateEngineStream( stream )

--- a/lua/entities/gtav_blazer.lua
+++ b/lua/entities/gtav_blazer.lua
@@ -37,11 +37,11 @@ if CLIENT then
 
     ENT.LightSprites = {
         { type = "brake", offset = Vector( -33, 0, 9 ), dir = Vector( -1, 0, 0 ), lightRadius = 50 },
-        { type = "headlight", offset = Vector( 20, 0, 9 ), dir = Vector( 1, 0, 0 ), color = Glide.DEFAULT_HEADLIGHT_COLOR }
+        { type = "headlight", offset = Vector( 20, 0, 9 ), dir = Vector( 1, 0, 0 ) }
     }
 
     ENT.Headlights = {
-        { offset = Vector( 19, 0, 18 ), color = Glide.DEFAULT_HEADLIGHT_COLOR }
+        { offset = Vector( 19, 0, 18 ) }
     }
 
     ENT.StartSound = "Glide.Engine.BikeStart1"

--- a/lua/entities/gtav_dukes.lua
+++ b/lua/entities/gtav_dukes.lua
@@ -25,8 +25,8 @@ if CLIENT then
     }
 
     ENT.Headlights = {
-        { offset = Vector( 102, 25, 2 ), color = Glide.DEFAULT_HEADLIGHT_COLOR },
-        { offset = Vector( 102, -25, 2 ), color = Glide.DEFAULT_HEADLIGHT_COLOR }
+        { offset = Vector( 102, 25, 2 ) },
+        { offset = Vector( 102, -25, 2 ) }
     }
 
     ENT.LightSprites = {
@@ -34,10 +34,10 @@ if CLIENT then
         { type = "brake", offset = Vector( -125, -13, 5 ), dir = Vector( -1, 0, 0 ) },
         { type = "reverse", offset = Vector( -125, 21, 5 ), dir = Vector( -1, 0, 0 ) },
         { type = "reverse", offset = Vector( -125, -21, 5 ), dir = Vector( -1, 0, 0 ) },
-        { type = "headlight", offset = Vector( 106, 29, -1 ), dir = Vector( 1, 0, 0 ), color = Glide.DEFAULT_HEADLIGHT_COLOR },
-        { type = "headlight", offset = Vector( 106, 22, -1 ), dir = Vector( 1, 0, 0 ), color = Glide.DEFAULT_HEADLIGHT_COLOR },
-        { type = "headlight", offset = Vector( 106, -29, -1 ), dir = Vector( 1, 0, 0 ), color = Glide.DEFAULT_HEADLIGHT_COLOR },
-        { type = "headlight", offset = Vector( 106, -22, -1 ), dir = Vector( 1, 0, 0 ), color = Glide.DEFAULT_HEADLIGHT_COLOR }
+        { type = "headlight", offset = Vector( 106, 29, -1 ), dir = Vector( 1, 0, 0 ) },
+        { type = "headlight", offset = Vector( 106, 22, -1 ), dir = Vector( 1, 0, 0 ) },
+        { type = "headlight", offset = Vector( 106, -29, -1 ), dir = Vector( 1, 0, 0 ) },
+        { type = "headlight", offset = Vector( 106, -22, -1 ), dir = Vector( 1, 0, 0 ) }
     }
 
     function ENT:OnCreateEngineStream( stream )

--- a/lua/entities/gtav_gauntlet_classic.lua
+++ b/lua/entities/gtav_gauntlet_classic.lua
@@ -37,15 +37,15 @@ if CLIENT then
     }
 
     ENT.Headlights = {
-        { offset = Vector( 102, 25, 14 ), color = Glide.DEFAULT_HEADLIGHT_COLOR },
-        { offset = Vector( 102, -25, 14 ), color = Glide.DEFAULT_HEADLIGHT_COLOR }
+        { offset = Vector( 102, 25, 14 ) },
+        { offset = Vector( 102, -25, 14 ) }
     }
 
     ENT.LightSprites = {
-        { type = "headlight", offset = Vector( 104, 33, 13.5 ), dir = Vector( 1, 0, 0 ), color = Glide.DEFAULT_HEADLIGHT_COLOR },
-        { type = "headlight", offset = Vector( 104, 25.5, 13.5 ), dir = Vector( 1, 0, 0 ), color = Glide.DEFAULT_HEADLIGHT_COLOR },
-        { type = "headlight", offset = Vector( 104, -33, 13.5 ), dir = Vector( 1, 0, 0 ), color = Glide.DEFAULT_HEADLIGHT_COLOR },
-        { type = "headlight", offset = Vector( 104, -25.5, 13.5 ), dir = Vector( 1, 0, 0 ), color = Glide.DEFAULT_HEADLIGHT_COLOR },
+        { type = "headlight", offset = Vector( 104, 33, 13.5 ), dir = Vector( 1, 0, 0 ) },
+        { type = "headlight", offset = Vector( 104, 25.5, 13.5 ), dir = Vector( 1, 0, 0 ) },
+        { type = "headlight", offset = Vector( 104, -33, 13.5 ), dir = Vector( 1, 0, 0 ) },
+        { type = "headlight", offset = Vector( 104, -25.5, 13.5 ), dir = Vector( 1, 0, 0 ) },
         { type = "brake", offset = Vector( -100, 19, 18 ), dir = Vector( -1, 0, 0 ) },
         { type = "brake", offset = Vector( -100, -19, 18 ), dir = Vector( -1, 0, 0 ) },
         { type = "reverse", offset = Vector( -99, 27, 6 ), dir = Vector( -1, 0, 0 ) },

--- a/lua/entities/gtav_sanchez.lua
+++ b/lua/entities/gtav_sanchez.lua
@@ -27,11 +27,11 @@ if CLIENT then
 
     ENT.LightSprites = {
         { type = "brake", offset = Vector( -43, 0, 17.5 ), dir = Vector( -1, 0, 0 ), lightRadius = 50 },
-        { type = "headlight", offset = Vector( 26, 0, 19.6 ), dir = Vector( 1, 0, 0 ), color = Glide.DEFAULT_HEADLIGHT_COLOR }
+        { type = "headlight", offset = Vector( 26, 0, 19.6 ), dir = Vector( 1, 0, 0 ) }
     }
 
     ENT.Headlights = {
-        { offset = Vector( 28, 0, 27 ), color = Glide.DEFAULT_HEADLIGHT_COLOR }
+        { offset = Vector( 28, 0, 27 ) }
     }
 
     function ENT:OnCreateEngineStream( stream )

--- a/lua/entities/gtav_speedo.lua
+++ b/lua/entities/gtav_speedo.lua
@@ -27,8 +27,8 @@ if CLIENT then
     }
 
     ENT.Headlights = {
-        { offset = Vector( 105, 32, 6.2 ), color = Glide.DEFAULT_HEADLIGHT_COLOR },
-        { offset = Vector( 105, -32, 6.2 ), color = Glide.DEFAULT_HEADLIGHT_COLOR },
+        { offset = Vector( 105, 32, 6.2 ) },
+        { offset = Vector( 105, -32, 6.2 ) },
     }
 
     ENT.LightSprites = {
@@ -36,8 +36,8 @@ if CLIENT then
         { type = "brake", offset = Vector( -118, -37, 20 ), dir = Vector( -1, 0, 0 ) },
         { type = "reverse", offset = Vector( -118, 38, 15 ), dir = Vector( -1, 0, 0 ) },
         { type = "reverse", offset = Vector( -118, -38, 15 ), dir = Vector( -1, 0, 0 ) },
-        { type = "headlight", offset = Vector( 105, 32, 6.2 ), dir = Vector( 1, 0, 0 ), color = Glide.DEFAULT_HEADLIGHT_COLOR },
-        { type = "headlight", offset = Vector( 105, -32, 6.2 ), dir = Vector( 1, 0, 0 ), color = Glide.DEFAULT_HEADLIGHT_COLOR }
+        { type = "headlight", offset = Vector( 105, 32, 6.2 ), dir = Vector( 1, 0, 0 ) },
+        { type = "headlight", offset = Vector( 105, -32, 6.2 ), dir = Vector( 1, 0, 0 ) }
     }
 
     function ENT:OnCreateEngineStream( stream )

--- a/lua/entities/gtav_wolfsbane.lua
+++ b/lua/entities/gtav_wolfsbane.lua
@@ -34,11 +34,11 @@ if CLIENT then
 
     ENT.LightSprites = {
         { type = "brake", offset = Vector( -45, 0, 5 ), dir = Vector( -1, 0, 0 ), lightRadius = 50 },
-        { type = "headlight", offset = Vector( 27, 0, 17 ), dir = Vector( 1, 0, 0 ), color = Glide.DEFAULT_HEADLIGHT_COLOR }
+        { type = "headlight", offset = Vector( 27, 0, 17 ), dir = Vector( 1, 0, 0 ) }
     }
 
     ENT.Headlights = {
-        { offset = Vector( 28, 0, 27 ), color = Glide.DEFAULT_HEADLIGHT_COLOR }
+        { offset = Vector( 28, 0, 27 ) }
     }
 
     function ENT:OnCreateEngineStream( stream )


### PR DESCRIPTION
- Colors passed through `ENT.Headlights` and `ENT.LightSprites` are ignored now
- Gives access to `vehicle:SetHeadlightColor( Vector )` and `vehicle:GetHeadlightColor()`
- The color's RGB values are in the **0.0-1.0** range, not on the **0-255** range

That last point is due to a limitation from the [entity editor](https://files.facepunch.com/wiki/files/entity_editor_example.jpg).