### PR TITLE
Allow gibs to be pushed by VJ NPCs

### DIFF
--- a/lua/entities/glide_gib.lua
+++ b/lua/entities/glide_gib.lua
@@ -6,6 +6,7 @@ ENT.PrintName = "Gib"
 
 ENT.Spawnable = false
 ENT.AdminOnly = false
+ENT.VJ_ID_Attackable = true
 
 ENT.PhysgunDisabled = true
 ENT.DoNotDuplicate = true


### PR DESCRIPTION
Settings this variable on the gibs will allow VJ NPCs that have a similar or larger size to the gib to push them towards the enemy. People can now witness a giant spider throwing a destroyed car towards them 😂
