### PR TITLE
Use crouch for thirdperson toggle

### DIFF
--- a/lua/glide/client/camera.lua
+++ b/lua/glide/client/camera.lua
@@ -238,7 +238,9 @@ function Camera:Think()
     end
 
     -- Toggle first person
-    local isSwitchKeyDown = IsKeyDown( KEY_LCONTROL ) and not vgui.CursorVisible()
+    local client = LocalPlayer()
+    local ducking = IsValid( client ) and client:KeyDown( IN_DUCK ) or false
+    local isSwitchKeyDown = ducking and not vgui.CursorVisible()
 
     if self.isSwitchKeyDown ~= isSwitchKeyDown then
         self.isSwitchKeyDown = isSwitchKeyDown


### PR DESCRIPTION
Just a little QOL change. My crouch key is actually 'alt' (yeah, weird I know) so this is more consistent with the GMod vehicle system

This in theory shouldn't break any of the default keybinds, since LCTRL is the default crouch key anyways.