### PR TITLE
Organizes vehicle categories in alphanumeric order

### DIFF
--- a/lua/glide/client/spawn_tab.lua
+++ b/lua/glide/client/spawn_tab.lua
@@ -63,7 +63,7 @@ hook.Add( "PopulateVehicles", "Glide.PopulateVehicles", function( panel, tree )
     local categories = list.Get( "GlideCategories" )
     local node = CreateCategory( tree, panel, "Glide", "glide/icons/car.png", "Default" )
 
-    for id, category in pairs( categories ) do
+    for id, category in SortedPairs( categories ) do
         CreateCategory( node, panel, category.name, category.icon, id )
     end
 


### PR DESCRIPTION
This is just a small change to reorganize the vehicle categories in alphanumeric order. 

# Before
![Before](https://github.com/user-attachments/assets/d24339cd-e08e-4b0d-8b5b-c1394b7cba80)

# After
![After](https://github.com/user-attachments/assets/7ac8130a-1def-4962-98c7-39210247f36a)
