### PR TITLE
Small `base_glide` think optimization

### DIFF
--- a/lua/entities/base_glide/init.lua
+++ b/lua/entities/base_glide/init.lua
@@ -568,8 +568,11 @@ function ENT:Think()
         if self:WaterLevel() > 2 then
             self:SetIsEngineOnFire( false )
         else
-            local attacker = IsValid( selfTbl.lastDamageAttacker ) and selfTbl.lastDamageAttacker or self
-            local inflictor = IsValid( selfTbl.lastDamageInflictor ) and selfTbl.lastDamageInflictor or self
+            local attacker = selfTbl.lastDamageAttacker 
+            if not attacker or not attacker:IsValid() then attacker = self end
+
+            local inflictor = selfTbl.lastDamageInflictor
+            if not inflictor or not inflictor:IsValid() then inflictor = self end
 
             local dmg = DamageInfo()
             dmg:SetDamage( selfTbl.MaxChassisHealth * selfTbl.ChassisFireDamageMultiplier * dt )

--- a/lua/entities/base_glide/init.lua
+++ b/lua/entities/base_glide/init.lua
@@ -557,7 +557,7 @@ function ENT:Think()
     end
 
     -- If necessary, kick passengers when underwater
-    if selfTbl.FallOnCollision and self:WaterLevel() > 2 and self:GetAllPlayers()[1] > 0 then
+    if selfTbl.FallOnCollision and self:WaterLevel() > 2 and self:GetAllPlayers()[1] then
         self:RagdollPlayers( 3 )
     end
 

--- a/lua/entities/base_glide/init.lua
+++ b/lua/entities/base_glide/init.lua
@@ -516,7 +516,7 @@ function ENT:Think()
     -- Update speed variables
     local localVelocity = self:GetPos()
     localVelocity:Add( self:GetVelocity() )
-    localVelocity:Set( self:WorldToLocal( localVelocity ) )
+    localVelocity = self:WorldToLocal( localVelocity )
     selfTbl.localVelocity = localVelocity
     selfTbl.forwardSpeed = localVelocity[1]
     selfTbl.totalSpeed = localVelocity:Length()


### PR DESCRIPTION
Using `:IsValid` instead of `IsValid`
Don't create extra vectors
Check if table is empty by first index, not by length
Using entity table instead of `__index` call where possible

For `dmg:SetDamageForce` does not require a unique vector
```lua
local dmg = DamageInfo()
dmg:SetDamage(10)
dmg:SetDamageForce(vector_origin)
Entity(1):TakeDamageInfo(dmg)

hook.Add("EntityTakeDamage", "gfg", function(target, dmg)
    print("dmg")
    local vec = dmg:GetDamageForce()
    print(vec, vector_origin)

    vec:SetUnpacked(5, 5, 5)
    print(vec, vector_origin)
end)
```
![image](https://github.com/user-attachments/assets/c68395f3-65ab-4a25-b9af-3806ccc50845)