### PR TITLE
Fix lua error

### DIFF
--- a/lua/entities/base_glide/init.lua
+++ b/lua/entities/base_glide/init.lua
@@ -194,15 +194,6 @@ function ENT:InitializePhysics()
     self:PhysicsInit( SOLID_VPHYSICS )
 end
 
-function ENT:OnRemove()
-    -- Stop physics processing
-    local phys = self:GetPhysicsObject()
-
-    if IsValid( phys ) then
-        self:StopMotionController()
-    end
-end
-
 function ENT:UpdateTransmitState()
     return 2 -- TRANSMIT_PVS
 end


### PR DESCRIPTION
Fixes:
```
[Glide // Styled's Vehicle Base] Cannot call StopMotionController in a physics callback!
1. unknown - lua/entities/base_glide/init.lua:202
```
Why stop Motion Controller if the entity is already very close to being removed. I deleted this part of code and it didn't seem to break anything