### PR TITLE
Allow disable explosive bullets

### DIFF
--- a/lua/autorun/sh_glide.lua
+++ b/lua/autorun/sh_glide.lua
@@ -179,6 +179,7 @@ CreateConVar( "sbox_maxglide_missile_launchers", "5", FCVAR_ARCHIVE + FCVAR_NOTI
 CreateConVar( "sbox_maxglide_projectile_launchers", "5", FCVAR_ARCHIVE + FCVAR_NOTIFY + FCVAR_REPLICATED, "Max. number of Glide Projectile Launchers that one player can have", 0 )
 
 -- Turret tool convars
+CreateConVar( "glide_turret_explosive_allow", "1", FCVAR_ARCHIVE + FCVAR_NOTIFY + FCVAR_REPLICATED, "Allows Glide Turrets to use explosive bullets.", 0, 1 )
 CreateConVar( "glide_turret_max_damage", "50", FCVAR_ARCHIVE + FCVAR_NOTIFY + FCVAR_REPLICATED, "Maximum damage dealt per bullet for Glide Turrets.", 0 )
 CreateConVar( "glide_turret_min_delay", "0.02", FCVAR_ARCHIVE + FCVAR_NOTIFY + FCVAR_REPLICATED, "Minimum delay allowed for Glide Turrets.", 0, 1 )
 

--- a/lua/entities/glide_standalone_turret.lua
+++ b/lua/entities/glide_standalone_turret.lua
@@ -91,6 +91,7 @@ function ENT:PostEntityPaste( ply, ent, createdEntities )
     Glide.PostEntityPaste( ply, ent, createdEntities )
 
     -- Update parameters in case the limits/console variables are not set to default
+    self:SetTurretExplosive( self.isExplosive )
     self:SetTurretDamage( self.turretDamage )
     self:SetTurretDelay( self.turretDelay )
     self:SetTurretSpread( self.turretSpread )
@@ -188,8 +189,13 @@ function ENT:UpdateTurret( t )
     }, self.traceFilter )
 end
 
+local cvarExplosive = GetConVar( "glide_turret_explosive_allow" )
 local cvarMaxDamage = GetConVar( "glide_turret_max_damage" )
 local cvarMinDelay = GetConVar( "glide_turret_min_delay" )
+
+function ENT:SetTurretExplosive( bool )
+    self.isExplosive = cvarExplosive:GetBool() and bool or false
+end
 
 function ENT:SetTurretDamage( damage )
     self.turretDamage = math.Clamp( damage, 1, cvarMaxDamage and cvarMaxDamage:GetFloat() or 50 )

--- a/lua/weapons/gmod_tool/stools/glide_turret.lua
+++ b/lua/weapons/gmod_tool/stools/glide_turret.lua
@@ -42,11 +42,11 @@ if SERVER then
         local g = self:GetClientNumber( "tracer_g", 160 )
         local b = self:GetClientNumber( "tracer_b", 35 )
 
+        ent:SetTurretExplosive( isExplosive )
         ent:SetTurretDelay( delay )
         ent:SetTurretDamage( damage )
         ent:SetTurretSpread( spread )
         ent:SetTracerColor( r, g, b )
-        ent.isExplosive = isExplosive
 
         local preset = SOUND_PRESETS[presetId]
 


### PR DESCRIPTION
Adds a convar to disable explosive bullets in Glide Turrets because i'm tired of kids putting a turret with zero delay and explosive bullets
