### PR TITLE
Use player.Iterator in some places

### DIFF
--- a/lua/glide/client/config.lua
+++ b/lua/glide/client/config.lua
@@ -898,7 +898,7 @@ hook.Add( "Tick", "Glide.CheckVoiceActivity", function()
     local isAnyoneTalking = false
 
     for _, ply in player.Iterator() do
-        if ply:IsVoiceAudible() and ply:VoiceVolume() > 0.05 then
+        if ply:IsValid() and ply:IsVoiceAudible() and ply:VoiceVolume() > 0.05 then
             isAnyoneTalking = true
             break
         end

--- a/lua/glide/client/config.lua
+++ b/lua/glide/client/config.lua
@@ -895,12 +895,9 @@ local Approach = math.Approach
 local glideVolume = 1
 
 hook.Add( "Tick", "Glide.CheckVoiceActivity", function()
-    local players = player.GetAll()
-    local ply, isAnyoneTalking = nil, false
+    local isAnyoneTalking = false
 
-    for i = 1, #players do
-        ply = players[i]
-
+    for _, ply in player.Iterator() do
         if ply:IsVoiceAudible() and ply:VoiceVolume() > 0.05 then
             isAnyoneTalking = true
             break

--- a/lua/glide/server/sound_modifiers.lua
+++ b/lua/glide/server/sound_modifiers.lua
@@ -55,7 +55,7 @@ timer.Create( "Glide.UpdateModSync", 1, 0, function()
         if IsValid( mod.vehicle ) then
             -- Sync modifiers with clients
             for _, ply in player.Iterator() do
-                if not ply:IsBot() then
+                if ply:IsValid() and not ply:IsBot() then
                     synced = mod.synced
 
                     -- If we have not synced this modifier to this player yet...

--- a/lua/glide/server/sound_modifiers.lua
+++ b/lua/glide/server/sound_modifiers.lua
@@ -46,8 +46,6 @@ end
 local Remove = table.remove
 
 timer.Create( "Glide.UpdateModSync", 1, 0, function()
-    local players = player.GetHumans()
-
     -- Reverse loop to cleanup invalid entities
     local mod, synced
 
@@ -56,13 +54,15 @@ timer.Create( "Glide.UpdateModSync", 1, 0, function()
 
         if IsValid( mod.vehicle ) then
             -- Sync modifiers with clients
-            for _, ply in ipairs( players ) do
-                synced = mod.synced
+            for _, ply in player.Iterator() do
+                if not ply:IsBot() then
+                    synced = mod.synced
 
-                -- If we have not synced this modifier to this player yet...
-                if not synced[ply] and ply.GlideLoaded then
-                    synced[ply] = true
-                    SendEntityModifierTo( ply, mod )
+                    -- If we have not synced this modifier to this player yet...
+                    if not synced[ply] and ply.GlideLoaded then
+                        synced[ply] = true
+                        SendEntityModifierTo( ply, mod )
+                    end
                 end
             end
         else


### PR DESCRIPTION
Replaces the last calls to `player.Get*` with `player.Iterator`. Replacing it with `player.Iterator` in the `Tick` hook effectively gives us (and other addons) an infinitely fast cache forever.
