### PR TITLE
Refactor duplicated logic

### DIFF
--- a/lua/entities/base_glide/cl_init.lua
+++ b/lua/entities/base_glide/cl_init.lua
@@ -58,10 +58,18 @@ function ENT:OnRemove( fullUpdate )
     end
 end
 
-function ENT:OnEngineStateChange( _, _, state )
-    if state > 0 then
+function ENT:OnEngineStateChange( _, lastState, state )
+    if state == 1 then
+        -- If we have a "startup" sound, play it now.
+        if self.rfSounds and self.rfSounds.isActive and self.StartSound and self.StartSound ~= "" then
+            local snd = self:CreateLoopingSound( "start", Glide.GetRandomSound( self.StartSound ), 70, self )
+            snd:PlayEx( 1, 100 )
+        end
+
+    elseif lastState ~= 3 and state == 2 then
         self:OnTurnOn()
-    else
+
+    elseif state == 0 then
         self:OnTurnOff()
     end
 end
@@ -138,6 +146,17 @@ function ENT:UpdateSounds()
             elseif not signalBlink and self.TurnSignalTickOffSound ~= "" then
                 self:EmitSound( self.TurnSignalTickOffSound, 65, self.TurnSignalPitch, self.TurnSignalVolume )
             end
+        end
+    end
+
+    local sounds = self.sounds
+
+    if sounds.start and self:GetEngineState() ~= 1 then
+        sounds.start:Stop()
+        sounds.start = nil
+
+        if self.StartTailSound and self.StartTailSound ~= "" then
+            Glide.PlaySoundSet( self.StartTailSound, self )
         end
     end
 

--- a/lua/entities/base_glide/cl_lights.lua
+++ b/lua/entities/base_glide/cl_lights.lua
@@ -120,7 +120,7 @@ function ENT:UpdateLights()
     -- Handle sprites
     local allowLights = self:IsEngineOn() or headlightState > 0
 
-    lightState.brake = allowLights and self:GetIsBraking()
+    lightState.brake = allowLights and self:IsBraking()
     lightState.reverse = allowLights and self:IsReversing()
     lightState.headlight = headlightState > 0
     lightState.taillight = headlightState > 0

--- a/lua/entities/base_glide/init.lua
+++ b/lua/entities/base_glide/init.lua
@@ -249,18 +249,32 @@ function ENT:Use( activator )
     end
 end
 
---- Sets the "EngineState" network variable to `1` and calls `ENT:OnTurnOn`.
-function ENT:TurnOn()
-    if self:GetEngineHealth() > 0 then
-        self:SetEngineState( 1 )
+function ENT:OnEngineStateChange( _, lastState, state )
+    if lastState == 1 and state == 2 then
         self:OnTurnOn()
+
+    elseif state == 0 then
+        self:OnTurnOff()
+    end
+
+    if WireLib then
+        WireLib.TriggerOutput( self, "EngineState", state )
     end
 end
 
---- Sets the "EngineState" network variable to `0` and calls `ENT:OnTurnOff`.
+function ENT:TurnOn()
+    local state = self:GetEngineState()
+
+    if state == 3 then
+        self:SetEngineState( 2 )
+
+    elseif state ~= 2 then
+        self:SetEngineState( 1 )
+    end
+end
+
 function ENT:TurnOff()
-    self:SetEngineState( 0 )
-    self:OnTurnOff()
+    self:SetEngineState( 3 )
 
     if self.autoTurnOffLights then
         self:ChangeHeadlightState( 0, true )

--- a/lua/entities/base_glide/shared.lua
+++ b/lua/entities/base_glide/shared.lua
@@ -106,13 +106,15 @@ function ENT:IsEngineOn()
     return self:GetEngineState() > 0
 end
 
--- You can safely override these on children classes.
+-- You can safely override this on children classes.
 -- Used to update bodygroups and draw sprites while in reverse gear.
 function ENT:IsReversing()
     return false
 end
 
-function ENT:GetIsBraking()
+-- You can safely override this on children classes.
+-- Used to update bodygroups and draw sprites while braking.
+function ENT:IsBraking()
     return self:GetBrakeValue() > 0.1
 end
 

--- a/lua/entities/base_glide/shared.lua
+++ b/lua/entities/base_glide/shared.lua
@@ -24,6 +24,15 @@ ENT.CanSwitchHeadlights = false
 -- How long is the on/off cycle for turn signals?
 ENT.TurnSignalCycle = 0.8
 
+--[[
+    For all vehicles, the values on Get/SetEngineState mean:
+
+    0 - Off
+    1 - Starting
+    2 - Running
+    3 - Shutting down or Ignition/Fuel cut-off
+]]
+
 function ENT:SetupDataTables()
     -- Setup default network variables. Do not override these slots
     -- when creating children classes! You can omit the 3rd "slot"
@@ -79,10 +88,10 @@ function ENT:SetupDataTables()
     self:SetHeadlightState( 0 )
     self:SetTurnSignalState( 0 )
 
-    if CLIENT then
-        -- Callback used to run `OnTurnOn` and `OnTurnOff` clientside
-        self:NetworkVarNotify( "EngineState", self.OnEngineStateChange )
+    -- Callback used to run `ENT:OnTurnOn` and `ENT:OnTurnOff`
+    self:NetworkVarNotify( "EngineState", self.OnEngineStateChange )
 
+    if CLIENT then
         -- Callback used to run `OnSwitchWeapon` clientside
         self:NetworkVarNotify( "WeaponIndex", self.OnWeaponIndexChange )
 
@@ -103,7 +112,7 @@ end
 
 -- You can safely override these on children classes
 function ENT:IsEngineOn()
-    return self:GetEngineState() > 0
+    return self:GetEngineState() > 1
 end
 
 -- You can safely override this on children classes.
@@ -118,6 +127,7 @@ function ENT:IsBraking()
     return self:GetBrakeValue() > 0.1
 end
 
+-- You can safely override these on children classes.
 function ENT:OnPostInitialize() end
 function ENT:OnEntityReload() end
 function ENT:OnTurnOn() end
@@ -125,8 +135,9 @@ function ENT:OnTurnOff() end
 function ENT:OnSwitchWeapon( _weaponIndex ) end
 function ENT:UpdatePlayerPoseParameters( _ply ) return false end
 
--- drive_airboat, drive_pd, sit, sit_rollercoaster
 function ENT:GetPlayerSitSequence( seatIndex )
+    -- Some sequences I'm aware of are:
+    -- drive_airboat, drive_pd, sit, sit_rollercoaster
     return seatIndex > 1 and "sit" or "drive_jeep"
 end
 
@@ -155,6 +166,10 @@ if CLIENT then
     -- Setup how far away players can hear sounds and update misc. features
     ENT.MaxSoundDistance = 6000
     ENT.MaxMiscDistance = 3000
+
+    -- Startup/ignition sounds, leave empty to disable
+    ENT.StartSound = ""
+    ENT.StartTailSound = ""
 
     -- Set label/icons for each weapon slot.
     -- This should contain a array of tables, where each table looks like these:
@@ -386,6 +401,7 @@ if SERVER then
         outputs[#outputs + 1] = { "MaxChassisHealth", "NORMAL", "Max. chassis health" }
         outputs[#outputs + 1] = { "ChassisHealth", "NORMAL", "Current chassis health (between 0.0 and MaxChassisHealth)" }
         outputs[#outputs + 1] = { "EngineHealth", "NORMAL", "Current engine health (between 0.0 and 1.0)" }
+        outputs[#outputs + 1] = { "EngineState", "NORMAL", "0: Off\n1: Starting\n2: Running\n3: Shutting down/Ignition cut-off" }
         outputs[#outputs + 1] = { "Active", "NORMAL", "0: No driver\n1: Has a driver" }
         outputs[#outputs + 1] = { "Driver", "ENTITY", "The current driver" }
         outputs[#outputs + 1] = { "DriverSeat", "ENTITY", "The driver seat" }

--- a/lua/entities/base_glide/sv_input.lua
+++ b/lua/entities/base_glide/sv_input.lua
@@ -113,8 +113,16 @@ function ENT:SetInputBool( seatIndex, action, pressed )
         self:DisconnectAllSockets()
     end
 
-    if seatIndex == 1 then
-        WakePhysics( self )
+    if seatIndex > 1 then return end
+
+    WakePhysics( self )
+
+    if action == "toggle_engine" then
+        if self:GetEngineState() == 0 then
+            self:TurnOn()
+        else
+            self:TurnOff()
+        end
     end
 end
 

--- a/lua/entities/base_glide/sv_input.lua
+++ b/lua/entities/base_glide/sv_input.lua
@@ -61,6 +61,16 @@ do
     end
 end
 
+local function WakePhysics( self )
+    -- Make sure the physics stay awake when necessary,
+    -- otherwise the driver's input won't do anything.
+    local phys = self:GetPhysicsObject()
+
+    if phys:IsValid() and phys:IsAsleep() then
+        phys:Wake()
+    end
+end
+
 function ENT:SetInputBool( seatIndex, action, pressed )
     local handled = self:OnSeatInput( seatIndex, action, pressed )
     if handled then return end
@@ -102,6 +112,10 @@ function ENT:SetInputBool( seatIndex, action, pressed )
     elseif action == "detach_trailer" and self.socketCount > 0 then
         self:DisconnectAllSockets()
     end
+
+    if seatIndex == 1 then
+        WakePhysics( self )
+    end
 end
 
 function ENT:SetInputFloat( seatIndex, action, value )
@@ -109,6 +123,10 @@ function ENT:SetInputFloat( seatIndex, action, value )
 
     if floats then
         floats[action] = value
+    end
+
+    if seatIndex == 1 then
+        WakePhysics( self )
     end
 end
 

--- a/lua/entities/base_glide/sv_lights.lua
+++ b/lua/entities/base_glide/sv_lights.lua
@@ -43,7 +43,7 @@ function ENT:UpdateLightBodygroups()
     local headlightState = self:GetHeadlightState()
     local allowLights = self:IsEngineOn() or headlightState > 0
 
-    lightState.brake = allowLights and self:GetIsBraking()
+    lightState.brake = allowLights and self:IsBraking()
     lightState.reverse = allowLights and self:IsReversing()
     lightState.headlight = headlightState > 0
 

--- a/lua/entities/base_glide_aircraft/init.lua
+++ b/lua/entities/base_glide_aircraft/init.lua
@@ -247,7 +247,6 @@ function ENT:OnSeatInput( seatIndex, action, pressed )
     if action == "countermeasures" then
         self:FireCountermeasures()
         return true
-
     end
 end
 

--- a/lua/entities/base_glide_aircraft/init.lua
+++ b/lua/entities/base_glide_aircraft/init.lua
@@ -50,7 +50,6 @@ function ENT:SetupWiremodPorts( inputs, outputs )
     inputs[#inputs + 1] = { "Fire", "NORMAL", "When greater than 0, fires the current weapon,\nif this helicopter has one" }
     inputs[#inputs + 1] = { "WeaponIndex", "NORMAL", "If this vehicle has weapons, this will set which one to use.\nStarts at index 1. Check the 'WeaponCount' output to see the max. value." }
 
-    outputs[#outputs + 1] = { "EngineState", "NORMAL", "0: Off\n1: Running" }
     outputs[#outputs + 1] = { "Power", "NORMAL", "Current engine power (between 0.0 and 2.0)" }
     outputs[#outputs + 1] = { "Altitude", "NORMAL", "Current vehicle altitude" }
     outputs[#outputs + 1] = { "WeaponCount", "NORMAL", "Number of weapon slots this vehicle has" }
@@ -258,8 +257,6 @@ function ENT:OnSeatInput( seatIndex, action, pressed )
     end
 end
 
-local TriggerOutput = WireLib and WireLib.TriggerOutput or nil
-
 --- Implement this base class function.
 function ENT:OnPostThink( dt, selfTbl )
     -- Find the altitude
@@ -272,10 +269,6 @@ function ENT:OnPostThink( dt, selfTbl )
 
     -- Update rotors
     self:RotorsThink()
-
-    if TriggerOutput then
-        TriggerOutput( self, "EngineState", self:GetEngineState() )
-    end
 end
 
 local IsValid = IsValid
@@ -358,6 +351,7 @@ end
 
 local WORLD_UP = Vector( 0, 0, 1 )
 local TraceLine = util.TraceLine
+local TriggerOutput = WireLib and WireLib.TriggerOutput or nil
 
 function ENT:UpdateAltitude()
     local mins = self:OBBMins()

--- a/lua/entities/base_glide_aircraft/init.lua
+++ b/lua/entities/base_glide_aircraft/init.lua
@@ -248,12 +248,6 @@ function ENT:OnSeatInput( seatIndex, action, pressed )
         self:FireCountermeasures()
         return true
 
-    elseif action == "toggle_engine" then
-        if self:GetEngineState() == 0 then
-            self:TurnOn()
-        else
-            self:TurnOff()
-        end
     end
 end
 

--- a/lua/entities/base_glide_boat/cl_init.lua
+++ b/lua/entities/base_glide_boat/cl_init.lua
@@ -9,22 +9,6 @@ function ENT:OnPostInitialize()
     self.streamJSONOverride = nil
 end
 
---- Override this base class function.
-function ENT:OnEngineStateChange( _, lastState, state )
-    if state == 1 then
-        if self.rfSounds and self.rfSounds.isActive then
-            local snd = self:CreateLoopingSound( "start", Glide.GetRandomSound( self.StartSound ), 70, self )
-            snd:PlayEx( 1, 100 )
-        end
-
-    elseif lastState == 1 and state == 2 then
-        self:OnTurnOn()
-
-    elseif state == 0 then
-        self:OnTurnOff()
-    end
-end
-
 local GetVolume = Glide.Config.GetVolume
 
 --- Implement this base class function.
@@ -63,12 +47,6 @@ local FrameTime = FrameTime
 --- Implement this base class function.
 function ENT:OnUpdateSounds()
     local sounds = self.sounds
-
-    if sounds.start and self:GetEngineState() ~= 1 then
-        sounds.start:Stop()
-        sounds.start = nil
-        Glide.PlaySoundSet( self.StartTailSound, self )
-    end
 
     local dt = FrameTime()
     local isHonking = self:GetIsHonking()

--- a/lua/entities/base_glide_boat/init.lua
+++ b/lua/entities/base_glide_boat/init.lua
@@ -68,13 +68,6 @@ function ENT:OnTakeDamage( dmginfo )
 end
 
 --- Override this base class function.
-function ENT:TurnOn()
-    if self:GetEngineState() < 1 then
-        self:SetEngineState( 1 )
-    end
-end
-
---- Override this base class function.
 function ENT:TurnOff()
     BaseClass.TurnOff( self )
 
@@ -104,7 +97,6 @@ function ENT:OnPostThink( dt, selfTbl )
 
                 if health > 0 then
                     self:SetEngineState( 2 )
-                    self:OnTurnOn()
                 else
                     self:SetEngineState( 0 )
                 end
@@ -113,6 +105,10 @@ function ENT:OnPostThink( dt, selfTbl )
             local startupTime = health < 0.5 and math.Rand( 1, 2 ) or selfTbl.StartupTime
             selfTbl.startupTimer = CurTime() + startupTime
         end
+
+    elseif state == 3 then
+        -- This vehicle does not do a "shutdown" sequence.
+        self:SetEngineState( 0 )
     end
 
     if self:IsEngineOn() then

--- a/lua/entities/base_glide_boat/init.lua
+++ b/lua/entities/base_glide_boat/init.lua
@@ -46,16 +46,6 @@ function ENT:OnSeatInput( seatIndex, action, pressed )
     if action == "horn" then
         self:SetIsHonking( pressed )
     end
-
-    if not pressed then return end
-
-    if action == "toggle_engine" then
-        if self:GetEngineState() == 0 then
-            self:TurnOn()
-        else
-            self:TurnOff()
-        end
-    end
 end
 
 --- Override this base class function.

--- a/lua/entities/base_glide_boat/init.lua
+++ b/lua/entities/base_glide_boat/init.lua
@@ -113,18 +113,6 @@ function ENT:OnPostThink( dt, selfTbl )
 
     if self:IsEngineOn() then
         self:UpdateEngine( dt, selfTbl )
-
-        -- Make sure the physics stay awake when necessary,
-        -- otherwise the driver's input won't do anything.
-        local phys = self:GetPhysicsObject()
-
-        if IsValid( phys ) and phys:IsAsleep() then
-            local driverInput = self:GetInputFloat( 1, "accelerate" ) + self:GetInputFloat( 1, "brake" ) + self:GetInputFloat( 1, "steer" )
-
-            if Abs( driverInput ) > 0.01 then
-                phys:Wake()
-            end
-        end
     end
 
     -- Update steer input

--- a/lua/entities/base_glide_boat/shared.lua
+++ b/lua/entities/base_glide_boat/shared.lua
@@ -10,14 +10,6 @@ ENT.AutomaticFrameAdvance = true
 ENT.VehicleType = Glide.VEHICLE_TYPE.BOAT
 ENT.CanSwitchHeadlights = true
 
---[[
-    For boats, the values on Get/SetEngineState mean:
-
-    0 - Off
-    1 - Starting
-    2 - Running
-]]
-
 DEFINE_BASECLASS( "base_glide" )
 
 --- Override this base class function.
@@ -40,11 +32,6 @@ function ENT:UpdatePlayerPoseParameters( ply )
     end
 
     return true
-end
-
---- Override this base class function.
-function ENT:IsEngineOn()
-    return self:GetEngineState() > 1
 end
 
 if CLIENT then

--- a/lua/entities/base_glide_car/cl_init.lua
+++ b/lua/entities/base_glide_car/cl_init.lua
@@ -28,22 +28,6 @@ function ENT:OnGearChange( _, _, gear )
     end
 end
 
---- Override this base class function.
-function ENT:OnEngineStateChange( _, lastState, state )
-    if state == 1 then
-        if self.rfSounds and self.rfSounds.isActive then
-            local snd = self:CreateLoopingSound( "start", Glide.GetRandomSound( self.StartSound ), 70, self )
-            snd:PlayEx( 1, 100 )
-        end
-
-    elseif lastState ~= 3 and state == 2 then
-        self:OnTurnOn()
-
-    elseif state == 0 then
-        self:OnTurnOff()
-    end
-end
-
 local GetVolume = Glide.Config.GetVolume
 
 --- Implement this base class function.
@@ -114,12 +98,6 @@ local Min = math.min
 --- Implement this base class function.
 function ENT:OnUpdateSounds()
     local sounds = self.sounds
-
-    if sounds.start and self:GetEngineState() ~= 1 then
-        sounds.start:Stop()
-        sounds.start = nil
-        Glide.PlaySoundSet( self.StartTailSound, self )
-    end
 
     local dt = FrameTime()
     local isSirenEnabled = self.lastSirenEnableTime and CurTime() - self.lastSirenEnableTime > 0.25

--- a/lua/entities/base_glide_car/cl_init.lua
+++ b/lua/entities/base_glide_car/cl_init.lua
@@ -195,15 +195,17 @@ function ENT:OnUpdateSounds()
     local stream = self.stream
 
     if not stream then
-        self.stream = Glide.CreateEngineStream( self )
+        if self:GetEngineState() < 3 then
+            self.stream = Glide.CreateEngineStream( self )
 
-        if self.streamJSONOverride then
-            self.stream:LoadJSON( self.streamJSONOverride )
-        else
-            self:OnCreateEngineStream( self.stream )
+            if self.streamJSONOverride then
+                self.stream:LoadJSON( self.streamJSONOverride )
+            else
+                self:OnCreateEngineStream( self.stream )
+            end
+
+            self.stream:Play()
         end
-
-        self.stream:Play()
 
         return
     end

--- a/lua/entities/base_glide_car/init.lua
+++ b/lua/entities/base_glide_car/init.lua
@@ -219,13 +219,6 @@ function ENT:OnSeatInput( seatIndex, action, pressed )
             immediate = true
         } )
 
-    elseif action == "toggle_engine" then
-        if self:GetEngineState() == 0 then
-            self:TurnOn()
-        else
-            self:TurnOff()
-        end
-
     elseif action == "accelerate" and self:GetEngineState() == 0 then
         self:TurnOn()
     end

--- a/lua/entities/base_glide_car/init.lua
+++ b/lua/entities/base_glide_car/init.lua
@@ -158,20 +158,10 @@ end
 
 --- Override this base class function.
 function ENT:TurnOn()
+    BaseClass.TurnOn( self )
+
     self.reducedThrottle = false
     self:SetGear( 0 )
-
-    local state = self:GetEngineState()
-
-    if state == 3 then
-        self:SetEngineState( 2 )
-        return
-    end
-
-    if state ~= 2 then
-        self:SetEngineState( 1 )
-    end
-
     self:SetFlywheelRPM( 0 )
 end
 
@@ -180,7 +170,6 @@ function ENT:TurnOff()
     BaseClass.TurnOff( self )
 
     self:SetIsHonking( false )
-    self:SetEngineState( 3 )
     self:SetGear( 0 )
     self.startupTimer = nil
 
@@ -316,7 +305,6 @@ function ENT:SetupWiremodPorts( inputs, outputs )
 
     outputs[#outputs + 1] = { "MaxGear", "NORMAL", "Highest gear available for this vehicle" }
     outputs[#outputs + 1] = { "Gear", "NORMAL", "Current engine gear" }
-    outputs[#outputs + 1] = { "EngineState", "NORMAL", "0: Off\n1: Starting\n2: Running\n3: Shutting down/Ignition cut-off" }
     outputs[#outputs + 1] = { "EngineRPM", "NORMAL", "Current engine RPM" }
     outputs[#outputs + 1] = { "MaxRPM", "NORMAL", "Max. engine RPM" }
 
@@ -358,7 +346,6 @@ function ENT:OnPostThink( dt, selfTbl )
         local maxRPM = self:GetMaxRPM()
         TriggerOutput( self, "MaxRPM", maxRPM )
         TriggerOutput( self, "Gear", self:GetGear() )
-        TriggerOutput( self, "EngineState", state )
         TriggerOutput( self, "EngineRPM", Clamp( self:GetFlywheelRPM(), 0, maxRPM ) )
 
         if selfTbl.wireSetEngineOn ~= nil then

--- a/lua/entities/base_glide_car/init.lua
+++ b/lua/entities/base_glide_car/init.lua
@@ -408,18 +408,6 @@ function ENT:OnPostThink( dt, selfTbl )
     end
 
     if self:IsEngineOn() then
-        -- Make sure the physics stay awake,
-        -- otherwise the driver's input won't do anything.
-        local phys = self:GetPhysicsObject()
-
-        if IsValid( phys ) and phys:IsAsleep() then
-            local driverInput = self:GetInputFloat( 1, "accelerate" ) + self:GetInputFloat( 1, "brake" )
-
-            if Abs( driverInput ) > 0.01 then
-                phys:Wake()
-            end
-        end
-
         -- Ignition cut-off, slowdown the flywheel and then turn off
         if state == 3 then
             local rpm = self:GetFlywheelRPM()

--- a/lua/entities/base_glide_car/shared.lua
+++ b/lua/entities/base_glide_car/shared.lua
@@ -20,15 +20,6 @@ ENT.CanSwitchHeadlights = true
 
 DEFINE_BASECLASS( "base_glide" )
 
---[[
-    For cars, the values on Get/SetEngineState mean:
-
-    0 - Off
-    1 - Starting
-    2 - Running
-    3 - Shutting down or Ignition/Fuel cut-off
-]]
-
 --- Override this base class function.
 function ENT:SetupDataTables()
     BaseClass.SetupDataTables( self )
@@ -130,11 +121,6 @@ function ENT:UpdatePlayerPoseParameters( ply )
     end
 
     return true
-end
-
---- Override this base class function.
-function ENT:IsEngineOn()
-    return self:GetEngineState() > 1
 end
 
 --- Override this base class function.

--- a/lua/entities/base_glide_heli/cl_init.lua
+++ b/lua/entities/base_glide_heli/cl_init.lua
@@ -17,7 +17,7 @@ end
 --- Implement this base class function.
 function ENT:OnTurnOn()
     if self:GetPower() < 0.1 then
-        self:EmitSound( self.StartSoundPath, 80, 100, 0.6 )
+        self:EmitSound( self.StartSound, 80, 100, 0.6 )
     end
 end
 

--- a/lua/entities/base_glide_heli/init.lua
+++ b/lua/entities/base_glide_heli/init.lua
@@ -36,6 +36,12 @@ function ENT:Repair()
     self:CreateRotors()
 end
 
+--- Override this base class function.
+function ENT:TurnOff()
+    BaseClass.TurnOff( self )
+    self:SetEngineState( 0 )
+end
+
 --- Creates and stores a new rotor entity.
 ---
 --- `radius` is used for collision checking.

--- a/lua/entities/base_glide_heli/init.lua
+++ b/lua/entities/base_glide_heli/init.lua
@@ -115,7 +115,6 @@ function ENT:RemoveRotorWash()
     end
 end
 
-local IsValid = IsValid
 local Approach = math.Approach
 local ExpDecay = Glide.ExpDecay
 local TriggerOutput = WireLib and WireLib.TriggerOutput or nil
@@ -149,14 +148,6 @@ function ENT:OnPostThink( dt, selfTbl )
     local isEngineDying = false
 
     if self:IsEngineOn() then
-        -- Make sure the physics stay awake,
-        -- otherwise the driver's input won't do anything.
-        local phys = self:GetPhysicsObject()
-
-        if IsValid( phys ) and phys:IsAsleep() then
-            phys:Wake()
-        end
-
         if self:GetEngineHealth() > 0 then
             -- Approach towards the idle power plus the offset
             local powerOffset = throttle * 0.2

--- a/lua/entities/base_glide_heli/init.lua
+++ b/lua/entities/base_glide_heli/init.lua
@@ -71,6 +71,8 @@ end
 --- Override this base class function.
 function ENT:TurnOn()
     BaseClass.TurnOn( self )
+
+    self:SetEngineState( 2 )
     self:SetOutOfControl( false )
 end
 

--- a/lua/entities/base_glide_heli/shared.lua
+++ b/lua/entities/base_glide_heli/shared.lua
@@ -37,7 +37,7 @@ end
 if CLIENT then
 
     -- Play this sound at startup
-    ENT.StartSoundPath = "glide/helicopters/start_1.wav"
+    ENT.StartSound = "glide/helicopters/start_1.wav"
 
     -- Play this sound at the tail rotor
     ENT.TailSoundPath = "glide/helicopters/tail_rotor_1.wav"

--- a/lua/entities/base_glide_plane/cl_init.lua
+++ b/lua/entities/base_glide_plane/cl_init.lua
@@ -5,7 +5,7 @@ DEFINE_BASECLASS( "base_glide_aircraft" )
 --- Implement the base class `OnTurnOn` function.
 function ENT:OnTurnOn()
     if self:GetPower() < 0.01 then
-        self:EmitSound( self.StartSoundPath, 80, 100, 0.6 )
+        self:EmitSound( self.StartSound, 80, 100, 0.6 )
     end
 end
 

--- a/lua/entities/base_glide_plane/init.lua
+++ b/lua/entities/base_glide_plane/init.lua
@@ -73,6 +73,8 @@ end
 --- Override this base class function.
 function ENT:TurnOn()
     BaseClass.TurnOn( self )
+
+    self:SetEngineState( 2 )
     self:SetExtraPitch( 1 )
     self.divePitch = 0
 end

--- a/lua/entities/base_glide_plane/init.lua
+++ b/lua/entities/base_glide_plane/init.lua
@@ -80,6 +80,8 @@ end
 --- Override this base class function.
 function ENT:TurnOff()
     BaseClass.TurnOff( self )
+
+    self:SetEngineState( 0 )
     self:SetExtraPitch( 1 )
     self.divePitch = 0
 end

--- a/lua/entities/base_glide_plane/init.lua
+++ b/lua/entities/base_glide_plane/init.lua
@@ -144,8 +144,6 @@ function ENT:OnPostThink( dt, selfTbl )
     self:SetThrottle( throttle )
 
     if self:IsEngineOn() then
-        -- Make sure the physics stay awake,
-        -- otherwise the driver's input won't do anything.
         local phys = self:GetPhysicsObject()
 
         if IsValid( phys ) then
@@ -154,10 +152,6 @@ function ENT:OnPostThink( dt, selfTbl )
 
             selfTbl.divePitch = Approach( selfTbl.divePitch, downDot > 0.5 and downDot or 0, dt * 0.5 )
             self:SetExtraPitch( Approach( self:GetExtraPitch(), 1 + pitchVel + ( selfTbl.divePitch * 0.3 ), dt * 0.1 ) )
-
-            if phys:IsAsleep() then
-                phys:Wake()
-            end
         end
 
         if self:GetEngineHealth() > 0 then

--- a/lua/entities/base_glide_plane/shared.lua
+++ b/lua/entities/base_glide_plane/shared.lua
@@ -32,7 +32,7 @@ if CLIENT then
     ENT.MaxSoundDistance = 15000
 
     -- Play this sound at startup
-    ENT.StartSoundPath = "glide/aircraft/start_3.wav"
+    ENT.StartSound = "glide/aircraft/start_3.wav"
 
     -- Play this sound from far away
     ENT.DistantSoundPath = "glide/aircraft/distant_stunt.wav"

--- a/lua/entities/base_glide_tank/cl_init.lua
+++ b/lua/entities/base_glide_tank/cl_init.lua
@@ -42,22 +42,6 @@ function ENT:OnLocalPlayerExit()
     self.isPredicted = false
 end
 
---- Override this base class function.
-function ENT:OnEngineStateChange( _, _, state )
-    if state == 1 then
-        if self.rfSounds and self.rfSounds.isActive then
-            local snd = self:CreateLoopingSound( "start", Glide.GetRandomSound( self.StartSound ), 70, self )
-            snd:PlayEx( 1, 100 )
-        end
-
-    elseif state == 2 then
-        self:OnTurnOn()
-
-    elseif state == 0 then
-        self:OnTurnOff()
-    end
-end
-
 --- Implement this base class function.
 function ENT:OnDeactivateSounds()
     if self.stream then
@@ -194,12 +178,6 @@ end
 --- Implement this base class function.
 function ENT:OnUpdateSounds()
     local sounds = self.sounds
-
-    if sounds.start and self:GetEngineState() ~= 1 then
-        sounds.start:Stop()
-        sounds.start = nil
-        Glide.PlaySoundSet( self.StartTailSound, self )
-    end
 
     if not self:IsEngineOn() then return end
 

--- a/lua/entities/base_glide_tank/init.lua
+++ b/lua/entities/base_glide_tank/init.lua
@@ -39,11 +39,7 @@ end
 
 --- Override this base class function.
 function ENT:TurnOn()
-    local state = self:GetEngineState()
-
-    if state ~= 2 then
-        self:SetEngineState( 1 )
-    end
+    BaseClass.TurnOn( self )
 
     self:SetEngineThrottle( 0 )
     self:SetEnginePower( 0 )
@@ -245,6 +241,10 @@ function ENT:OnPostThink( dt, selfTbl )
             local startupTime = health < 0.5 and math.Rand( 1, 2 ) or selfTbl.StartupTime
             selfTbl.startupTimer = CurTime() + startupTime
         end
+
+    elseif state == 3 then
+        -- This vehicle does not do a "shutdown" sequence.
+        self:SetEngineState( 0 )
     end
 
     if self:IsEngineOn() then

--- a/lua/entities/base_glide_tank/init.lua
+++ b/lua/entities/base_glide_tank/init.lua
@@ -250,20 +250,12 @@ function ENT:OnPostThink( dt, selfTbl )
     if self:IsEngineOn() then
         self:UpdateEngine( dt )
 
-        -- Make sure the physics stay awake when necessary,
-        -- otherwise the driver's input won't do anything.
         local phys = self:GetPhysicsObject()
 
         if IsValid( phys ) and phys:IsAsleep() then
             self:SetTrackSpeed( 0 )
             selfTbl.availableTorqueL = 0
             selfTbl.availableTorqueR = 0
-
-            local driverInput = self:GetInputFloat( 1, "accelerate" ) + self:GetInputFloat( 1, "brake" ) + self:GetInputFloat( 1, "steer" )
-
-            if Abs( driverInput ) > 0.01 then
-                phys:Wake()
-            end
         end
     end
 

--- a/lua/entities/base_glide_tank/init.lua
+++ b/lua/entities/base_glide_tank/init.lua
@@ -56,19 +56,6 @@ function ENT:TurnOff()
     self.brake = 0.5
 end
 
---- Implement this base class function.
-function ENT:OnSeatInput( seatIndex, action, pressed )
-    if not pressed or seatIndex > 1 then return end
-
-    if action == "toggle_engine" then
-        if self:GetEngineState() == 0 then
-            self:TurnOn()
-        else
-            self:TurnOff()
-        end
-    end
-end
-
 --- Override this base class function.
 function ENT:OnTakeDamage( dmginfo )
     if dmginfo:IsDamageType( 64 ) then -- DMG_BLAST

--- a/lua/entities/base_glide_tank/shared.lua
+++ b/lua/entities/base_glide_tank/shared.lua
@@ -20,14 +20,6 @@ ENT.LowPitchAng = 10
 ENT.MaxYawSpeed = 50
 ENT.YawSpeed = 1500
 
---[[
-    For tanks, the values on Get/SetEngineState mean:
-
-    0 - Off
-    1 - Starting
-    2 - Running
-]]
-
 DEFINE_BASECLASS( "base_glide" )
 
 --- Override this base class function.
@@ -40,11 +32,6 @@ function ENT:SetupDataTables()
 
     self:NetworkVar( "Angle", "TurretAngle" )
     self:NetworkVar( "Bool", "IsAimingAtTarget" )
-end
-
---- Override this base class function.
-function ENT:IsEngineOn()
-    return self:GetEngineState() > 1
 end
 
 --- Override this base class function.

--- a/lua/entities/gtav_lazer.lua
+++ b/lua/entities/gtav_lazer.lua
@@ -40,7 +40,7 @@ if CLIENT then
         { offset = Vector( -235, 0, 8 ), angle = Angle( 270, 0, 0 ), scale = 0.9 }
     }
 
-    ENT.StartSoundPath = "glide/aircraft/start_4.wav"
+    ENT.StartSound = "glide/aircraft/start_4.wav"
     ENT.DistantSoundPath = "glide/aircraft/jet_stream.wav"
 
     ENT.PropSoundPath = "glide/aircraft/thrust_b11.wav"

--- a/lua/entities/gtav_strikeforce.lua
+++ b/lua/entities/gtav_strikeforce.lua
@@ -50,7 +50,7 @@ if CLIENT then
         { offset = Vector( -175, -50, 25 ), angle = Angle( 270, 0, 0 ), scale = 0.7 }
     }
 
-    ENT.StartSoundPath = "glide/aircraft/start_4.wav"
+    ENT.StartSound = "glide/aircraft/start_4.wav"
     ENT.DistantSoundPath = "glide/aircraft/jet_stream.wav"
     ENT.PropSoundPath = ""
 


### PR DESCRIPTION
This pull request is meant to merge a bunch of duplicate code scattered around base vehicle types into the main `base_glide` class.

- Made all engine states have the same meaning on all vehicle types
- Moved `ENT.StartSound` and `ENT.StartTailSound` logic to `base_glide`
- Renamed helicopter/plane `ENT.StartSoundPath` to `ENT.StartSound`, to match other vehicle types
- Moved EngineState Wiremod output logic to `base_glide`
- Moved the "wake physics on input" logic to `base_glide`
- Moved the "engine toggle button" check to `base_glide`