### PR TITLE
Optimize `UpdateLightBodygroups` by only updating bodygroup when necessary

### DIFF
--- a/lua/entities/base_glide/sv_lights.lua
+++ b/lua/entities/base_glide/sv_lights.lua
@@ -82,6 +82,9 @@ function ENT:UpdateLightBodygroups()
             enable = false
         end
 
-        self:SetBodygroup( l.bodyGroupId, enable and l.subModelId or 0 )
+        local targetSubModel = enable and l.subModelId or 0
+        if self:GetBodygroup( l.bodyGroupId ) ~= targetSubModel then
+            self:SetBodygroup( l.bodyGroupId, targetSubModel )
+        end
     end
 end


### PR DESCRIPTION
hey, while taking a quick look at the FProfiler results with your base installed, I noticed `UpdateLightBodygroups` being quite high up there. This was caused by `Entity:SetBodygroup` being called very often every tick.

I've updated that function so that it only updates the bodygroup when the target submodel differs from the current one.

This made the function ~450% faster in my quick testing.

Open for any feedback, especially since I haven't had time to get more familiar with the whole base.

Thanks for your great work!