### PR TITLE
Make tanks use `base_glide_car` as the parent class

### DIFF
--- a/lua/entities/base_glide/sv_wheels.lua
+++ b/lua/entities/base_glide/sv_wheels.lua
@@ -12,7 +12,6 @@ end
 
 function ENT:CreateWheel( offset, params )
     params = params or {}
-    params.localPos = offset
 
     local pos = self:LocalToWorld( offset )
     local ang = self:LocalToWorldAngles( Angle() )

--- a/lua/entities/base_glide_aircraft/init.lua
+++ b/lua/entities/base_glide_aircraft/init.lua
@@ -82,7 +82,6 @@ function ENT:CreateWheel( offset, params )
 
     params.forwardTractionMax = params.forwardTractionMax or 50000
     params.sideTractionMultiplier = params.sideTractionMultiplier or 200
-    params.sideTractionMinAng = params.sideTractionMinAng or 70
     params.brakePower = params.brakePower or 1000
 
     if params.enableAxleForces == nil then

--- a/lua/entities/base_glide_car/init.lua
+++ b/lua/entities/base_glide_car/init.lua
@@ -437,7 +437,7 @@ function ENT:OnPostThink( dt, selfTbl )
 
     local phys = self:GetPhysicsObject()
 
-    if selfTbl.groundedCount < 1 and IsValid( phys ) then
+    if selfTbl.groundedCount < 1 and IsValid( phys ) and self:WaterLevel() < 3 then
         if selfTbl.totalSpeed > 200 then
             self:UpdateAirControls( phys, dt )
         else

--- a/lua/entities/base_glide_tank/shared.lua
+++ b/lua/entities/base_glide_tank/shared.lua
@@ -120,9 +120,6 @@ if SERVER then
     ENT.SuspensionHeavySound = "Glide.Suspension.CompressTruck"
     ENT.SuspensionDownSound = "Glide.Suspension.Stress"
 
-    ENT.HornSound = "glide/horns/large_truck_horn_2.wav"
-    ENT.ExhaustPopSound = ""
-
     -- Setup a weapon slot for the turret
     ENT.WeaponSlots = {
         { maxAmmo = 0, fireRate = 2.0 },

--- a/lua/entities/base_glide_tank/shared.lua
+++ b/lua/entities/base_glide_tank/shared.lua
@@ -125,6 +125,13 @@ if SERVER then
         { maxAmmo = 0, fireRate = 2.0 },
     }
 
+    -- Can this tank "turn in place"?
+    ENT.CanTurnInPlace = true
+
+    -- How much extra torque to apply when trying to spin in place?
+    ENT.TurnInPlaceTorqueMultiplier = 3
+
+    -- Turret parameters
     ENT.TurretFireSound = ")glide/tanks/acf_fire4.mp3"
     ENT.TurretFireVolume = 0.8
     ENT.TurretRecoilForce = 50

--- a/lua/entities/gtav_rhino.lua
+++ b/lua/entities/gtav_rhino.lua
@@ -7,6 +7,10 @@ ENT.PrintName = "Rhino"
 ENT.GlideCategory = "Default"
 ENT.ChassisModel = "models/gta5/vehicles/rhino/chassis.mdl"
 
+-- The Rhino does not have these
+ENT.CanSwitchHeadlights = false
+ENT.CanSwitchTurnSignals = false
+
 DEFINE_BASECLASS( "base_glide_tank" )
 
 if CLIENT then
@@ -170,7 +174,7 @@ if SERVER then
         } )
 
         -- Middle left
-        self:CreateWheel( Vector( 5, 55, -5 ) )
+        self:CreateWheel( Vector( 5, 55, -5 ) ):SetSoundsEnabled( false )
 
         -- Rear left
         self:CreateWheel( Vector( -76, 55, -5 ), {
@@ -183,7 +187,7 @@ if SERVER then
         } )
 
         -- Middle right
-        self:CreateWheel( Vector( 5, -55, -5 ) )
+        self:CreateWheel( Vector( 5, -55, -5 ) ):SetSoundsEnabled( false )
 
         -- Rear right
         self:CreateWheel( Vector( -76, -55, -5 ), {

--- a/lua/entities/gtav_rhino.lua
+++ b/lua/entities/gtav_rhino.lua
@@ -25,6 +25,9 @@ if CLIENT then
         { offset = Vector( -130, -40, 18 ), angle = Angle( 0, 180, 0 ), width = 35 }
     }
 
+    ENT.HornSound = "glide/horns/large_truck_horn_2.wav"
+    ENT.ExhaustPopSound = ""
+
     function ENT:OnCreateEngineStream( stream )
         stream:LoadPreset( "rhino" )
         stream.offset = Vector( -30, 0, 0 )


### PR DESCRIPTION
This pull request turns the tank base into a child of the `base_glide_car` class (previously, it was a child of the `base_glide` class).

## Advantages

- Gives access to horns, sirens, headlights and turn signals to tanks
- Gives access to `ENT.IsAmphibious` to tanks
- Gives the same simulated car engine logic to tanks
- You can now modify the same engine parameters that cars have

By default, tank engine and suspension parameters try to mimic the behaviour that tanks had before this pull request. (Strong suspension, high torque, and only 3 gears - 1st, neutral and reverse)

## Tank `ENT` table changes:

- ➕ Added `ENT.CanTurnInPlace`
- ✏ Renamed `ENT.YawSpeed` to `ENT.YawAcceleration`
- ✏ Renamed `ENT.HighPitchAng` to `ENT.PitchAngMax`
- ✏ Renamed `ENT.LowPitchAng` to `ENT.PitchAngMin`
- ✏ Renamed `ENT.SpinEngineTorqueMultiplier` to `ENT.TurnInPlaceTorqueMultiplier`
- ❌ Removed `ENT.EngineTorque`
- ❌ Removed `ENT.MaxSpeed`
- ❌ Removed `ENT.MaxSteerAngle`

### Related issues:

- #102
- #133