### PR TITLE
Add mouse steering

### DIFF
--- a/lua/autorun/sh_glide.lua
+++ b/lua/autorun/sh_glide.lua
@@ -50,6 +50,13 @@ Glide.MOUSE_FLY_MODE = {
     CAMERA = 2      -- Free camera
 }
 
+-- Mouse steering control modes
+Glide.MOUSE_STEER_MODE = {
+    DISABLED = 0,   -- Use keyboard only
+    AIM = 1,        -- Steer towards aim direction
+    DIRECT = 2      -- Control movement directly
+}
+
 -- Default color for vehicle lights
 Glide.DEFAULT_HEADLIGHT_COLOR = Color( 255, 231, 176 )
 Glide.DEFAULT_TURN_SIGNAL_COLOR = Color( 255, 164, 45 )

--- a/lua/glide/client/mouse_input.lua
+++ b/lua/glide/client/mouse_input.lua
@@ -19,18 +19,49 @@ local Config = Glide.Config
 function MouseInput:Activate()
     local vehicle = Glide.currentVehicle
 
-    -- Only activate mouse input while being a aircraft pilot with direct mouse input enabled
-    if
-        not IsValid( vehicle ) or
-        not Glide.IsAircraft( vehicle ) or
-        Glide.currentSeatIndex > 1 or
-        Config.mouseFlyMode ~= Glide.MOUSE_FLY_MODE.DIRECT
-    then
+    if not IsValid( vehicle ) or Glide.currentSeatIndex > 1 then
         self:Deactivate()
+        return
+    end
+
+    -- If the local player is the pilot of a aircraft, with direct mouse flying enabled...
+    if Glide.IsAircraft( vehicle ) and Config.mouseFlyMode == Glide.MOUSE_FLY_MODE.DIRECT then
+        -- Activate mouse flying controls.
+        self:Prepare()
+
+        hook.Add( "HUDPaint", "Glide.DrawMouseInput", function()
+            self:DrawFlyingHUD()
+        end )
+
+        hook.Add( "InputMouseApply", "Glide.UpdateMouseInput", function( _, x, y )
+            self:ApplyFlyingInput( x, y )
+        end )
 
         return
     end
 
+    -- If the local player is not on a aircraft, with direct mouse steering enabled...
+    if
+        not Glide.IsAircraft( vehicle )
+        and Config.mouseSteerMode == Glide.MOUSE_STEER_MODE.DIRECT
+        and vehicle:GetCameraType( 1 ) == Glide.CAMERA_TYPE.CAR
+    then
+        -- Activate mouse steering controls.
+        self:Prepare()
+
+        hook.Add( "InputMouseApply", "Glide.UpdateMouseInput", function( _, x, _ )
+            self:ApplySteeringInput( x )
+        end )
+
+        return
+    end
+
+    -- If none of the checks above returned early,
+    -- then no mouse input should be active client-side.
+    self:Deactivate()
+end
+
+function MouseInput:Prepare()
     self.mouse = { 0, 0 }
     self.freeLook = false
     self:Reset()
@@ -39,21 +70,13 @@ function MouseInput:Activate()
     self.cvarYaw = GetConVar( "glide_input_yaw" )
     self.cvarRoll = GetConVar( "glide_input_roll" )
 
-    hook.Add( "InputMouseApply", "Glide.UpdateMouseInput", function( _, x, y )
-        self:InputMouseApply( x, y )
-    end )
-
     hook.Add( "Think", "Glide.UpdateMouseInput", function()
-        local freeLook = input.IsKeyDown( Config.binds.aircraft_controls.free_look ) or vgui.CursorVisible()
+        local freeLook = input.IsKeyDown( Config.binds.general_controls.free_look ) or vgui.CursorVisible()
 
         if self.freeLook ~= freeLook then
             self.freeLook = freeLook
             self:Reset()
         end
-    end )
-
-    hook.Add( "HUDPaint", "Glide.DrawMouseInput", function()
-        self:DrawHUD()
     end )
 end
 
@@ -77,7 +100,7 @@ end
 local Abs = math.abs
 local Clamp = math.Clamp
 
-local function ConvertInput( axis, mouse, deadzone )
+local function ProcessInput( axis, mouse, deadzone )
     if axis == 0 then return 0 end
 
     local value = mouse[axis]
@@ -86,7 +109,7 @@ local function ConvertInput( axis, mouse, deadzone )
     return value
 end
 
-function MouseInput:InputMouseApply( x, y )
+function MouseInput:ApplyFlyingInput( x, y )
     if self.freeLook then return end
 
     x = Config.mouseInvertX and -x or x
@@ -98,13 +121,31 @@ function MouseInput:InputMouseApply( x, y )
     mouse[1] = Clamp( mouse[1] + x * Config.mouseSensitivityX * 0.01, -1, 1 )
     mouse[2] = Clamp( mouse[2] - y * Config.mouseSensitivityY * 0.01, -1, 1 )
 
-    local pitch = ConvertInput( Config.pitchMouseAxis, mouse, deadzone )
-    local yaw = ConvertInput( Config.yawMouseAxis, mouse, deadzone )
-    local roll = ConvertInput( Config.rollMouseAxis, mouse, deadzone )
+    local pitch = ProcessInput( Config.pitchMouseAxis, mouse, deadzone )
+    local yaw = ProcessInput( Config.yawMouseAxis, mouse, deadzone )
+    local roll = ProcessInput( Config.rollMouseAxis, mouse, deadzone )
 
     self.cvarPitch:SetFloat( pitch )
     self.cvarYaw:SetFloat( yaw )
     self.cvarRoll:SetFloat( roll )
+end
+
+local ExpDecay = Glide.ExpDecay
+
+function MouseInput:ApplySteeringInput( x )
+    if self.freeLook then return end
+
+    local mouse = self.mouse
+
+    mouse[1] = Clamp( mouse[1] + x * Config.mouseSteerSensitivity * 0.01, -1, 1 )
+    mouse[1] = ExpDecay( mouse[1], 0, Config.mouseSteerDecayRate, FrameTime() )
+    mouse[2] = 0
+
+    -- Make low values "ramp up" slightly faster
+    local steer = math.pow( Abs( mouse[1] ), 0.8 )
+    if mouse[1] < 0 then steer = -steer end
+
+    self.cvarPitch:SetFloat( steer )
 end
 
 local ScrW, ScrH = ScrW, ScrH
@@ -117,7 +158,7 @@ local DrawTexturedRectRotated = surface.DrawTexturedRectRotated
 local MAT_BACKGROUND = Material( "glide/mouse_area.png", "smooth" )
 local MAT_JOYSTICK = Material( "glide/mouse_joystick.png", "smooth" )
 
-function MouseInput:DrawHUD()
+function MouseInput:DrawFlyingHUD()
     if not Config.mouseShow then return end
     if self.freeLook then return end
 

--- a/lua/glide/server/input.lua
+++ b/lua/glide/server/input.lua
@@ -48,7 +48,8 @@ do
             binds = binds,
             manualGearShifting = data.manualGearShifting == true,
             autoTurnOffLights = data.autoTurnOffLights == true,
-            mouseFlyMode = math.Round( Glide.ValidateNumber( data.mouseFlyMode, 0, 2, 0 ) )
+            mouseFlyMode = math.Round( Glide.ValidateNumber( data.mouseFlyMode, 0, 2, 0 ) ),
+            mouseSteerMode = math.Round( Glide.ValidateNumber( data.mouseSteerMode, 0, 2, 0 ) )
         }
 
         -- Replace yaw actions with roll actions when the client asks for it,
@@ -233,7 +234,10 @@ local function HandleMouseInput( ply, active )
     if not settings then return end
 
     local vehTbl = getTable( vehicle )
-    -- Ignore is this vehicle is not an aircraft
+
+    -- TODO: mouse steering logic
+
+    -- Ignore if this vehicle is not an aircraft
     if vehTbl.VehicleType ~= 3 and vehTbl.VehicleType ~= 4 then return end
 
     -- Ignore if the mouse aim mode is "Free camera"

--- a/lua/glide/sh_input.lua
+++ b/lua/glide/sh_input.lua
@@ -14,6 +14,7 @@ InputCategories["general_controls"] = {
     ["switch_weapon"] = KEY_R,
     ["toggle_engine"] = KEY_I,
     ["headlights"] = KEY_H,
+    ["free_look"] = KEY_LALT,
 }
 
 -- Inputs that only apply to land vehicle types
@@ -47,7 +48,6 @@ InputCategories["aircraft_controls"] = {
     ["attack"] = MOUSE_LEFT,
     ["attack_alt"] = KEY_SPACE,
 
-    ["free_look"] = KEY_LALT,
     ["landing_gear"] = KEY_G,
     ["countermeasures"] = KEY_F,
 

--- a/resource/localization/en/glide_vehicles.properties
+++ b/resource/localization/en/glide_vehicles.properties
@@ -28,10 +28,12 @@ glide.camera.autocenter_delay=Auto-center delay
 # Settings - Mouse
 
 glide.settings.mouse=Mouse settings
+
+glide.mouse.flying_settings=Mouse flying settings
 glide.mouse.flying_mode=Mouse behaviour while flying
-glide.mouse.mode_aim=Point-to-aim
-glide.mouse.mode_direct=Control movement directly
-glide.mouse.mode_camera=Free camera (Use keyboard to pitch/roll)
+glide.mouse.fly_mode_aim=Point-to-aim
+glide.mouse.fly_mode_direct=Control movement directly
+glide.mouse.fly_mode_camera=Free camera (Use keyboard to pitch/roll)
 
 glide.mouse.pitch_axis=Pitch axis
 glide.mouse.yaw_axis=Yaw axis
@@ -45,6 +47,12 @@ glide.mouse.sensitivity_x=Horizontal sensitivity
 glide.mouse.sensitivity_y=Vertical sensitivity
 glide.mouse.deadzone=Deadzone
 glide.mouse.show_hud=Draw mouse status on screen
+
+glide.mouse.steering_settings=Mouse steering settings
+glide.mouse.steering_mode=Steer with the mouse
+glide.mouse.steer_mode_disabled=Disabled (Use keyboard only)
+glide.mouse.steer_mode_aim=Steer towards aim direction
+glide.mouse.steer_mode_direct=Control steering directly
 
 # Settings - Input
 

--- a/resource/localization/en/glide_vehicles.properties
+++ b/resource/localization/en/glide_vehicles.properties
@@ -49,6 +49,7 @@ glide.mouse.deadzone=Deadzone
 glide.mouse.show_hud=Draw mouse status on screen
 
 glide.mouse.steering_settings=Mouse steering settings
+glide.mouse.decay_rate=Decay rate
 glide.mouse.steering_mode=Steer with the mouse
 glide.mouse.steer_mode_disabled=Disabled (Use keyboard only)
 glide.mouse.steer_mode_aim=Steer towards aim direction

--- a/resource/localization/es-es/glide_vehicles.properties
+++ b/resource/localization/es-es/glide_vehicles.properties
@@ -28,10 +28,12 @@ glide.camera.autocenter_delay=Retraso de auto-centrado
 # Settings - Mouse
 
 glide.settings.mouse=Ajustes de ratón
+
+glide.mouse.flying_settings=Configuración de vuelo del ratón
 glide.mouse.flying_mode=Comportamiento de raton en vuelo
-glide.mouse.mode_aim=Pulsar para apuntar
-glide.mouse.mode_direct=Controlar movimiento
-glide.mouse.mode_camera=Free camera (Usa el teclado para controlar el vehículo)
+glide.mouse.fly_mode_aim=Pulsar para apuntar
+glide.mouse.fly_mode_direct=Controlar movimiento
+glide.mouse.fly_mode_camera=Cámara libre (Usa el teclado para controlar el vehículo)
 
 glide.mouse.pitch_axis=Eje de cabeceo
 glide.mouse.yaw_axis=Eje de guiñada
@@ -45,6 +47,12 @@ glide.mouse.sensitivity_x=Sensibilidad horizontal
 glide.mouse.sensitivity_y=Sensibilidad vertical
 glide.mouse.deadzone=Zona muerta
 glide.mouse.show_hud=Mostrar estado del ratón en pantalla
+
+glide.mouse.steering_settings=Configuraciones de dirección con el mouse
+glide.mouse.steering_mode=Dirigir con el ratón
+glide.mouse.steer_mode_disabled=Desactivado (Usar solo el teclado)
+glide.mouse.steer_mode_aim=Dirección en la dirección de puntería
+glide.mouse.steer_mode_direct=Controlar la dirección directamente
 
 # Settings - Input
 

--- a/resource/localization/es-es/glide_vehicles.properties
+++ b/resource/localization/es-es/glide_vehicles.properties
@@ -49,6 +49,7 @@ glide.mouse.deadzone=Zona muerta
 glide.mouse.show_hud=Mostrar estado del ratón en pantalla
 
 glide.mouse.steering_settings=Configuraciones de dirección con el mouse
+glide.mouse.decay_rate=Tasa de decaimiento
 glide.mouse.steering_mode=Dirigir con el ratón
 glide.mouse.steer_mode_disabled=Desactivado (Usar solo el teclado)
 glide.mouse.steer_mode_aim=Dirección en la dirección de puntería

--- a/resource/localization/fr/glide_vehicles.properties
+++ b/resource/localization/fr/glide_vehicles.properties
@@ -48,6 +48,7 @@ glide.mouse.deadzone=Zone morte
 glide.mouse.show_hud=Afficher l'état de la souris à l'écran
 
 glide.mouse.steering_settings=Paramètres de direction de la souris
+glide.mouse.decay_rate=Taux de décroissance
 glide.mouse.steering_mode=Conduire avec la souris
 glide.mouse.steer_mode_disabled=Désactivé (utilisation du clavier uniquement)
 glide.mouse.steer_mode_aim=Diriger vers la direction visée

--- a/resource/localization/fr/glide_vehicles.properties
+++ b/resource/localization/fr/glide_vehicles.properties
@@ -27,10 +27,12 @@ glide.camera.autocenter_delay=Délai de recentrage automatique
 # Paramètres - Souris
 
 glide.settings.mouse=Paramètres de la souris
+
+glide.mouse.flying_settings=Paramètres de vol de la souris
 glide.mouse.flying_mode=Comportement de la souris en vol
-glide.mouse.mode_aim=Pointer pour viser
-glide.mouse.mode_direct=Contrôler les mouvements directement
-glide.mouse.mode_camera=Caméra libre (Utiliser le clavier pour tangage/roulis)
+glide.mouse.fly_mode_aim=Pointer pour viser
+glide.mouse.fly_mode_direct=Contrôler les mouvements directement
+glide.mouse.fly_mode_camera=Caméra libre (Utiliser le clavier pour tangage/roulis)
 
 glide.mouse.pitch_axis=Axe de tangage
 glide.mouse.yaw_axis=Axe de lacet
@@ -44,6 +46,12 @@ glide.mouse.sensitivity_x=Sensibilité horizontale
 glide.mouse.sensitivity_y=Sensibilité verticale
 glide.mouse.deadzone=Zone morte
 glide.mouse.show_hud=Afficher l'état de la souris à l'écran
+
+glide.mouse.steering_settings=Paramètres de direction de la souris
+glide.mouse.steering_mode=Conduire avec la souris
+glide.mouse.steer_mode_disabled=Désactivé (utilisation du clavier uniquement)
+glide.mouse.steer_mode_aim=Diriger vers la direction visée
+glide.mouse.steer_mode_direct=Contrôle direct de la direction
 
 # Paramètres - Entrée
 

--- a/resource/localization/pt-br/glide_vehicles.properties
+++ b/resource/localization/pt-br/glide_vehicles.properties
@@ -28,10 +28,12 @@ glide.camera.autocenter_delay=Atraso do auto-centralizar
 # Settings - Mouse
 
 glide.settings.mouse=Opções do mouse
+
+glide.mouse.flying_settings=Configurações de voo do mouse
 glide.mouse.flying_mode=Comportanento ao voar
-glide.mouse.mode_aim=Aponte-para-mirar
-glide.mouse.mode_direct=Controlar movimento diretamente
-glide.mouse.mode_camera=Camera livre (Use o teclado para inclinar)
+glide.mouse.fly_mode_aim=Aponte-para-mirar
+glide.mouse.fly_mode_direct=Controlar movimento diretamente
+glide.mouse.fly_mode_camera=Camera livre (Use o teclado para inclinar)
 
 glide.mouse.pitch_axis=Eixo para inclinar
 glide.mouse.yaw_axis=Eixo para o leme
@@ -45,6 +47,12 @@ glide.mouse.sensitivity_x=Sensibilidade horizontal
 glide.mouse.sensitivity_y=Sensibilidade vertical
 glide.mouse.deadzone=Zona morta
 glide.mouse.show_hud=Mostrar o estado do mouse na tela
+
+glide.mouse.steering_settings=Configurações de direção do mouse
+glide.mouse.steering_mode=Dirigir com o mouse
+glide.mouse.steer_mode_disabled=Desativado (Somente teclado)
+glide.mouse.steer_mode_aim=Direcionar com a mira
+glide.mouse.steer_mode_direct=Dirigir diretamente
 
 # Settings - Input
 

--- a/resource/localization/pt-br/glide_vehicles.properties
+++ b/resource/localization/pt-br/glide_vehicles.properties
@@ -49,6 +49,7 @@ glide.mouse.deadzone=Zona morta
 glide.mouse.show_hud=Mostrar o estado do mouse na tela
 
 glide.mouse.steering_settings=Configurações de direção do mouse
+glide.mouse.decay_rate=Taxa de decaimento
 glide.mouse.steering_mode=Dirigir com o mouse
 glide.mouse.steer_mode_disabled=Desativado (Somente teclado)
 glide.mouse.steer_mode_aim=Direcionar com a mira

--- a/resource/localization/ru/glide_vehicles.properties
+++ b/resource/localization/ru/glide_vehicles.properties
@@ -28,10 +28,12 @@ glide.camera.autocenter_delay=Задержка автоцентрировани�
 # Settings - Mouse
 
 glide.settings.mouse=Настройки мыши
+
+glide.mouse.flying_settings=Настройки полета мыши
 glide.mouse.flying_mode=Поведение мыши во время полёта
-glide.mouse.mode_aim=Наведение
-glide.mouse.mode_direct=Прямое управление движением
-glide.mouse.mode_camera=Свободная камера (Управление клавиатурой)
+glide.mouse.fly_mode_aim=Наведение
+glide.mouse.fly_mode_direct=Прямое управление движением
+glide.mouse.fly_mode_camera=Свободная камера (Управление клавиатурой)
 
 glide.mouse.pitch_axis=Ось тангажа
 glide.mouse.yaw_axis=Ось рыскания
@@ -45,6 +47,12 @@ glide.mouse.sensitivity_x=Чувствительность по горизонт
 glide.mouse.sensitivity_y=Чувствительность по вертикали
 glide.mouse.deadzone=Мёртвая зона
 glide.mouse.show_hud=Отображать состояние мыши на экране
+
+glide.mouse.steering_settings=Настройки управления мышью
+glide.mouse.steering_mode=Вождение с помощью мыши
+glide.mouse.steer_mode_disabled=Отключено (используется только клавиатура)
+glide.mouse.steer_mode_aim=Руление в направлении цели
+glide.mouse.steer_mode_direct=Управление рулевым управлением напрямую
 
 # Settings - Input
 

--- a/resource/localization/ru/glide_vehicles.properties
+++ b/resource/localization/ru/glide_vehicles.properties
@@ -49,6 +49,7 @@ glide.mouse.deadzone=Мёртвая зона
 glide.mouse.show_hud=Отображать состояние мыши на экране
 
 glide.mouse.steering_settings=Настройки управления мышью
+glide.mouse.decay_rate=Скорость распада
 glide.mouse.steering_mode=Вождение с помощью мыши
 glide.mouse.steer_mode_disabled=Отключено (используется только клавиатура)
 glide.mouse.steer_mode_aim=Руление в направлении цели

--- a/resource/localization/tr/glide_vehicles.properties
+++ b/resource/localization/tr/glide_vehicles.properties
@@ -28,10 +28,12 @@ glide.camera.autocenter_delay=Otomatik ortalama gecikmesi
 # Settings - Mouse
 
 glide.settings.mouse=Fare ayarları
+
+glide.mouse.flying_settings=Fare uçma ayarları
 glide.mouse.flying_mode=Uçarken fare davranışı
-glide.mouse.mode_aim=Nişan almak için işaret et
-glide.mouse.mode_direct=Hareketi doğrudan kontrol et
-glide.mouse.mode_camera=Serbest kamera (yunuslama/yatış için klavyeyi kullan)
+glide.mouse.fly_mode_aim=Nişan almak için işaret et
+glide.mouse.fly_mode_direct=Hareketi doğrudan kontrol et
+glide.mouse.fly_mode_camera=Serbest kamera (yunuslama/yatış için klavyeyi kullan)
 
 glide.mouse.pitch_axis=Yunuslama ekseni
 glide.mouse.yaw_axis=Sapma ekseni
@@ -45,6 +47,12 @@ glide.mouse.sensitivity_x=Yatay hassasiyet
 glide.mouse.sensitivity_y=Dikey hassasiyet
 glide.mouse.deadzone=Algısız Bölge
 glide.mouse.show_hud=Fare durumunu ekranda göster
+
+glide.mouse.steering_settings=Fare direksiyon ayarları
+glide.mouse.steering_mode=Fare ile sürüş
+glide.mouse.steer_mode_disabled=Devre dışı (Yalnızca klavyeyi kullan)
+glide.mouse.steer_mode_aim=Nişan yönüne doğru yönlendir
+glide.mouse.steer_mode_direct=Direksiyona doğrudan kumanda et
 
 # Settings - Input
 

--- a/resource/localization/tr/glide_vehicles.properties
+++ b/resource/localization/tr/glide_vehicles.properties
@@ -49,6 +49,7 @@ glide.mouse.deadzone=Algısız Bölge
 glide.mouse.show_hud=Fare durumunu ekranda göster
 
 glide.mouse.steering_settings=Fare direksiyon ayarları
+glide.mouse.decay_rate=Çürüme oranı
 glide.mouse.steering_mode=Fare ile sürüş
 glide.mouse.steer_mode_disabled=Devre dışı (Yalnızca klavyeyi kullan)
 glide.mouse.steer_mode_aim=Nişan yönüne doğru yönlendir

--- a/resource/localization/uk/glide_vehicles.properties
+++ b/resource/localization/uk/glide_vehicles.properties
@@ -28,10 +28,12 @@ glide.camera.autocenter_delay=Затримка автоцентрування
 # Settings - Mouse
 
 glide.settings.mouse=Налаштування миші
+
+glide.mouse.flying_settings=Налаштування польоту миші
 glide.mouse.flying_mode=Керування мишею під час польоту
-glide.mouse.mode_aim=Наведення до миші (Point-to-aim)
-glide.mouse.mode_direct=Пряме керування рухом
-glide.mouse.mode_camera=Вільна камера (Використовуйте клавіатуру для крену/тангажу)
+glide.mouse.fly_mode_aim=Наведення до миші (Point-to-aim)
+glide.mouse.fly_mode_direct=Пряме керування рухом
+glide.mouse.fly_mode_camera=Вільна камера (Використовуйте клавіатуру для крену/тангажу)
 
 glide.mouse.pitch_axis=Вісь тангажу
 glide.mouse.yaw_axis=Вісь рискання
@@ -45,6 +47,12 @@ glide.mouse.sensitivity_x=Чутливість по горизонталі
 glide.mouse.sensitivity_y=Чутливість по вертикалі
 glide.mouse.deadzone=Мертва зона
 glide.mouse.show_hud=Відображати стан миші на екрані
+
+glide.mouse.steering_settings=Налаштування керування мишею
+glide.mouse.steering_mode=Керування за допомогою миші
+glide.mouse.steer_mode_disabled=Вимкнено (використовуйте лише клавіатуру)
+glide.mouse.steer_mode_aim=Керування в напрямку прицілювання
+glide.mouse.steer_mode_direct=Керування кермом безпосередньо
 
 # Settings - Input
 

--- a/resource/localization/uk/glide_vehicles.properties
+++ b/resource/localization/uk/glide_vehicles.properties
@@ -49,6 +49,7 @@ glide.mouse.deadzone=Мертва зона
 glide.mouse.show_hud=Відображати стан миші на екрані
 
 glide.mouse.steering_settings=Налаштування керування мишею
+glide.mouse.decay_rate=Швидкість розпаду
 glide.mouse.steering_mode=Керування за допомогою миші
 glide.mouse.steer_mode_disabled=Вимкнено (використовуйте лише клавіатуру)
 glide.mouse.steer_mode_aim=Керування в напрямку прицілювання


### PR DESCRIPTION
- Added two mouse steering *modes*: **Steer towards aim direction** and **Control steering directly**|
- Can be used on cars, motorcycles and boats
- Adjust camera auto-center depending on the mode
- Integrates with the "free look" keybind
- Integrates with the "fixed camera" settings