### PR TITLE
Use tracehull for missiles, bullets, projectiles

### DIFF
--- a/lua/entities/glide_missile/init.lua
+++ b/lua/entities/glide_missile/init.lua
@@ -147,7 +147,7 @@ local GetClosestFlare = Glide.GetClosestFlare
 local TraceHull = util.TraceHull
 
 local traceData = {
-    filter = { NULL },
+    filter = { NULL, NULL },
     mask = MASK_PLAYERSOLID,
     maxs = Vector(),
     mins = Vector()

--- a/lua/entities/glide_missile/init.lua
+++ b/lua/entities/glide_missile/init.lua
@@ -144,6 +144,14 @@ end
 local FrameTime = FrameTime
 local Approach = math.Approach
 local GetClosestFlare = Glide.GetClosestFlare
+local TraceHull = util.TraceHull
+
+local traceData = {
+    filter = { NULL },
+    mask = MASK_PLAYERSOLID,
+    maxs = Vector(),
+    mins = Vector()
+}
 
 function ENT:Think()
     local t = CurTime()
@@ -205,6 +213,16 @@ function ENT:Think()
         end
     else
         self:SetHasTarget( false )
+    end
+
+    traceData.start = myPos
+    traceData.endpos = myPos + self:GetVelocity() * dt * 2
+    traceData.filter[1] = self
+    traceData.filter[2] = self:GetOwner()
+
+    local tr = TraceHull( traceData )
+    if not tr.HitSky and tr.Hit then
+        self:Explode()
     end
 
     return true

--- a/lua/entities/glide_projectile.lua
+++ b/lua/entities/glide_projectile.lua
@@ -143,7 +143,7 @@ local TraceHull = util.TraceHull
 local GetDevMode = Glide.GetDevMode
 
 local traceData = {
-    filter = { NULL },
+    filter = { NULL, NULL },
     mask = MASK_PLAYERSOLID,
     maxs = Vector(),
     mins = Vector()

--- a/lua/entities/glide_projectile.lua
+++ b/lua/entities/glide_projectile.lua
@@ -139,12 +139,14 @@ function ENT:Explode()
 end
 
 local FrameTime = FrameTime
-local TraceLine = util.TraceLine
+local TraceHull = util.TraceHull
 local GetDevMode = Glide.GetDevMode
 
 local traceData = {
     filter = { NULL },
     mask = MASK_PLAYERSOLID,
+    maxs = Vector(),
+    mins = Vector()
 }
 
 function ENT:Think()
@@ -191,7 +193,7 @@ function ENT:Think()
         debugoverlay.Line( traceData.start, traceData.endpos, 0.75, Color( 255, 0, 0 ), true )
     end
 
-    local tr = TraceLine( traceData )
+    local tr = TraceHull( traceData )
 
     if tr.HitSky then
         self:Remove()

--- a/lua/glide/server/weaponry.lua
+++ b/lua/glide/server/weaponry.lua
@@ -58,7 +58,7 @@ end
 do
     local RandomFloat = math.Rand
     local Effect = util.Effect
-    local TraceLine = util.TraceLine
+    local TraceHull = util.TraceHull
     local EffectData = EffectData
 
     local pos, ang
@@ -93,12 +93,12 @@ do
         traceData.endpos = pos + dir * length
         traceData.filter = traceFilter
 
-        local tr = TraceLine( traceData )
+        local tr = TraceHull( traceData )
 
         if tr.Hit then
             length = length * tr.Fraction
 
-            local waterTrace = TraceLine( {
+            local waterTrace = TraceHull( {
                 start = traceData.start,
                 endpos = traceData.endpos,
                 mask = MASK_WATER


### PR DESCRIPTION
Currently glide is using traceline for a lot of its projectiles, tracelines go through parented entities which makes fighting player made contraptions pretty useless.
This pr converts them to use tracehull and adds tracehulls checks to missiles.