### PR TITLE
Override `ENTITY:IsVehicle` better

### DIFF
--- a/lua/autorun/sh_glide.lua
+++ b/lua/autorun/sh_glide.lua
@@ -394,17 +394,6 @@ do
     end
 end
 
-hook.Add( "Initialize", "Glide.OverrideIsVehicle", function()
-    local VehicleMeta = FindMetaTable( "Entity" )
-    local IsVehicle = VehicleMeta.IsVehicle
-
-    --- Override `Entity:IsVehicle` to return `true` on Glide vehicles.
-    --- Also keep compatibility with Simfphys.
-    function VehicleMeta:IsVehicle()
-        return ( self.IsSimfphyscar and self:IsSimfphyscar() ) or self.IsGlideVehicle or IsVehicle( self )
-    end
-end )
-
 local function IncludeDir( dirPath, doInclude, doTransfer )
     local files = file.Find( dirPath .. "*.lua", "LUA" )
     local path

--- a/lua/autorun/sh_glide.lua
+++ b/lua/autorun/sh_glide.lua
@@ -398,7 +398,6 @@ local EntityMeta = FindMetaTable( "Entity" )
 local IsVehicle = EntityMeta.IsVehicle
 
 --- Override `Entity:IsVehicle` to return `true` on Glide vehicles.
---- Also keep compatibility with Simfphys.
 function EntityMeta:IsVehicle()
     return IsVehicle( self ) or self.IsGlideVehicle
 end

--- a/lua/autorun/sh_glide.lua
+++ b/lua/autorun/sh_glide.lua
@@ -399,7 +399,7 @@ local IsVehicle = EntityMeta.IsVehicle
 
 --- Override `Entity:IsVehicle` to return `true` on Glide vehicles.
 function EntityMeta:IsVehicle()
-    return IsVehicle( self ) or self.IsGlideVehicle
+    return self.IsGlideVehicle or IsVehicle( self )
 end
 
 local function IncludeDir( dirPath, doInclude, doTransfer )

--- a/lua/autorun/sh_glide.lua
+++ b/lua/autorun/sh_glide.lua
@@ -394,16 +394,14 @@ do
     end
 end
 
-hook.Add( "Initialize", "Glide.OverrideIsVehicle", function()
-    local EntityMeta = FindMetaTable( "Entity" )
-    local IsVehicle = EntityMeta.IsVehicle
+local EntityMeta = FindMetaTable( "Entity" )
+local IsVehicle = EntityMeta.IsVehicle
 
-    --- Override `Entity:IsVehicle` to return `true` on Glide vehicles.
-    --- Also keep compatibility with Simfphys.
-    function EntityMeta:IsVehicle()
-        return self.IsGlideVehicle or IsVehicle( self )
-    end
-end )
+--- Override `Entity:IsVehicle` to return `true` on Glide vehicles.
+--- Also keep compatibility with Simfphys.
+function EntityMeta:IsVehicle()
+    return self.IsGlideVehicle or IsVehicle( self )
+end
 
 local function IncludeDir( dirPath, doInclude, doTransfer )
     local files = file.Find( dirPath .. "*.lua", "LUA" )

--- a/lua/autorun/sh_glide.lua
+++ b/lua/autorun/sh_glide.lua
@@ -394,6 +394,17 @@ do
     end
 end
 
+hook.Add( "Initialize", "Glide.OverrideIsVehicle", function()
+    local EntityMeta = FindMetaTable( "Entity" )
+    local IsVehicle = EntityMeta.IsVehicle
+
+    --- Override `Entity:IsVehicle` to return `true` on Glide vehicles.
+    --- Also keep compatibility with Simfphys.
+    function EntityMeta:IsVehicle()
+        return self.IsGlideVehicle or IsVehicle( self )
+    end
+end )
+
 local function IncludeDir( dirPath, doInclude, doTransfer )
     local files = file.Find( dirPath .. "*.lua", "LUA" )
     local path

--- a/lua/autorun/sh_glide.lua
+++ b/lua/autorun/sh_glide.lua
@@ -400,7 +400,7 @@ local IsVehicle = EntityMeta.IsVehicle
 --- Override `Entity:IsVehicle` to return `true` on Glide vehicles.
 --- Also keep compatibility with Simfphys.
 function EntityMeta:IsVehicle()
-    return self.IsGlideVehicle or IsVehicle( self )
+    return IsVehicle( self ) or self.IsGlideVehicle
 end
 
 local function IncludeDir( dirPath, doInclude, doTransfer )

--- a/lua/entities/base_glide/shared.lua
+++ b/lua/entities/base_glide/shared.lua
@@ -113,6 +113,10 @@ function ENT:GravGunPickupAllowed( _ply )
     return false
 end
 
+function ENT:IsVehicle()
+    return true
+end
+
 -- You can safely override these on children classes
 function ENT:IsEngineOn()
     return self:GetEngineState() > 1

--- a/lua/entities/base_glide/shared.lua
+++ b/lua/entities/base_glide/shared.lua
@@ -113,10 +113,6 @@ function ENT:GravGunPickupAllowed( _ply )
     return false
 end
 
-function ENT:IsVehicle()
-    return true
-end
-
 -- You can safely override these on children classes
 function ENT:IsEngineOn()
     return self:GetEngineState() > 1

--- a/lua/glide/server/weaponry.lua
+++ b/lua/glide/server/weaponry.lua
@@ -278,7 +278,6 @@ end
 
 local EntityMeta = FindMetaTable( "Entity" )
 local getClass = EntityMeta.GetClass
-local isVehicle = EntityMeta.IsVehicle
 local getParent = EntityMeta.GetParent
 
 local AllEnts = ents.Iterator
@@ -306,7 +305,7 @@ local function IsLockableEntity( ent, skipParentCheck )
         return true
     end
 
-    if isVehicle( ent ) then
+    if ent:IsVehicle() then
         return true
     end
 


### PR DESCRIPTION
All Is* checks in the entity, weapon, nextbot, vehicle, and player metatables are hard-coded to return `true` or `false`. For example, `ENTITY.IsVehicle` will always return `false`, and `VEHICLE.IsVehicle` will always return `true`.
```lua
lua_run print(FindMetaTable("Entity").IsVehicle(Entity(VEHICLE_EDICT)))
> false
```
https://github.com/user-attachments/assets/5b463466-0789-4146-b7d3-083bea7270d4