### PR TITLE
Changed `Glide.HideEntity` function

### DIFF
--- a/lua/autorun/sh_glide.lua
+++ b/lua/autorun/sh_glide.lua
@@ -346,13 +346,10 @@ function Glide.IsAircraft( vehicle )
 end
 
 do
-    local COLOR_HIDDEN = Color( 255, 255, 255, 0 )
-
     --- Hide entity without using `SetNoDraw`, because it stops networking the entity, 
     --- and removes the entity from the parent's `GetChildren` clientside.
     function Glide.HideEntity( ent, hide )
-        ent:SetRenderMode( hide and RENDERMODE_TRANSCOLOR or RENDERMODE_NORMAL )
-        ent:SetColor( hide and COLOR_HIDDEN or color_white )
+        ent:SetMaterial( hide and "null" or "" )
         ent.GlideIsHidden = Either( hide, true, nil )
     end
 end


### PR DESCRIPTION
Sets "null" material instead of changing color and render mode 
This makes entity invisible and also not drawing shadows from projected textures

# Before
![{F8E02816-54F2-4D2A-B453-F15B1992A39D}](https://github.com/user-attachments/assets/8a1253da-e927-483e-ae57-f02257056501)

# After
![{4B93CCDA-EE86-4BC0-8418-2BBFB3100BC7}](https://github.com/user-attachments/assets/db26391f-9cdb-411a-aef2-322f73467888)
