### PR TITLE
Fix lua error

### DIFF
--- a/lua/weapons/glide_homing_launcher.lua
+++ b/lua/weapons/glide_homing_launcher.lua
@@ -408,7 +408,7 @@ function SWEP:UpdateTarget()
                 -- If the target is another type of vehicle, notify the driver
                 local driver = target:GetDriver()
 
-                if IsValid( driver ) then
+                if IsValid( driver ) and driver:IsPlayer() then
                     Glide.SendLockOnDanger( driver )
                 end
             end


### PR DESCRIPTION
Fixes:
```
Warning! Trying to net.Send a message 'glide.command' to a non-player!
1. SendLockOnDanger - lua/glide/server/network.lua:173
 2. UpdateTarget - lua/weapons/glide_homing_launcher.lua:412
  3. <unknown> - lua/weapons/glide_homing_launcher.lua:233
```
The driver may not always be a player for engine vehicles, i don't know why, but it is so