### PR TITLE
Update lights per tick instead of frame

### DIFF
--- a/lua/entities/base_glide/cl_lights.lua
+++ b/lua/entities/base_glide/cl_lights.lua
@@ -104,11 +104,13 @@ function ENT:UpdateLights()
             l = self.activeHeadlights[index]
             hasLight = IsValid( l )
 
-            if hasLight then
+            local currentTick = engine.TickCount()
+            if hasLight and self.lastTick and currentTick > self.lastTick then
                 l:SetPos( self:LocalToWorld( data.offset ) )
                 l:SetAngles( self:LocalToWorldAngles( data.angles ) )
                 l:Update()
             end
+            self.lastTick = currentTick
 
             -- Check if this light no longer meets the optional bodygroup requirement.
             if data.ifBodygroupId and hasLight ~= ( self:GetBodygroup( data.ifBodygroupId ) == ( data.ifSubModelId or 0 ) ) then


### PR DESCRIPTION
Currently ProjectedTexture lights are updated every frame, while they only need to be updated every game tick. Calling :Update() is what makes projected textures expensive, this improves client performance a lot when a bunch of vehicles with multiple lights are around.

Most of the lag from glide clientside is due to this.

This is a bit specific to the lights, if you prefer a more global and unified system other parts can use feel free to edit my pr or close this and implement it yourself.

