### PR TITLE
Various localization files fixes

### DIFF
--- a/resource/localization/en/glide_vehicles.properties
+++ b/resource/localization/en/glide_vehicles.properties
@@ -369,3 +369,8 @@ SBoxLimit_glide_vehicles=You've hit the Glide vehicle limit!
 SBoxLimit_glide_turret=You've hit the Glide Turret limit!
 SBoxLimit_glide_missile_launcher=You've hit the Glide Missile Launcher limit!
 SBoxLimit_glide_projectile_launcher=You've hit the Glide Projectile Launcher limit!
+
+Cleanup_glide_vehicles=Glide Vehicles
+Cleanup_glide_standalone_turrets=Glide Standalone Turrets
+Cleanup_glide_missile_launchers=Glide Missile Launchers
+Cleanup_glide_projectile_launchers=Glide Projectile Launchers

--- a/resource/localization/es-es/glide_vehicles.properties
+++ b/resource/localization/es-es/glide_vehicles.properties
@@ -369,3 +369,8 @@ SBoxLimit_glide_vehicles=¡Has alcanzado el límite de vehículos Glide!
 SBoxLimit_glide_turret=¡Has alcanzado el límite de torretas Glide!
 SBoxLimit_glide_missile_launcher=¡Has alcanzado el límite de lanzadores de misiles Glide!
 SBoxLimit_glide_projectile_launcher=¡Has alcanzado el límite de lanzadores de proyectiles Glide!
+
+Cleanup_glide_vehicles=Glide vehículos
+Cleanup_glide_standalone_turrets=Glide torretas
+Cleanup_glide_missile_launchers=Glide lanzadores de misiles
+Cleanup_glide_projectile_launchers=Glide lanzadores de proyectiles

--- a/resource/localization/fr/glide_vehicles.properties
+++ b/resource/localization/fr/glide_vehicles.properties
@@ -368,3 +368,8 @@ SBoxLimit_glide_vehicles=Vous avez atteint la limite de véhicules Glide !
 SBoxLimit_glide_turret=Vous avez atteint la limite de tourelles Glide !
 SBoxLimit_glide_missile_launcher=Vous avez atteint la limite de lance-missiles Glide !
 SBoxLimit_glide_projectile_launcher=Vous avez atteint la limite de lance-projectiles Glide !
+
+Cleanup_glide_vehicles=Glide véhicules
+Cleanup_glide_standalone_turrets=Glide tourelles
+Cleanup_glide_missile_launchers=Glide lance-missiles
+Cleanup_glide_projectile_launchers=Glide lance-projectiles

--- a/resource/localization/fr/glide_vehicles.properties
+++ b/resource/localization/fr/glide_vehicles.properties
@@ -18,6 +18,7 @@ glide.camera.fov_external=Champ de vision (troisième personne)
 glide.camera.shake_strength=Intensité du tremblement de l'appareil photo
 
 glide.camera.fixed=Caméra fixe
+glide.camera.fixed.disabled=Désactivé
 glide.camera.fixed.firstperson=Première personne uniquement
 glide.camera.fixed.thirdperson=Troisième personne uniquement
 glide.camera.fixed.both=Première et troisième personne

--- a/resource/localization/pt-br/glide_vehicles.properties
+++ b/resource/localization/pt-br/glide_vehicles.properties
@@ -369,3 +369,8 @@ SBoxLimit_glide_vehicles=Você atingiu o limite do veículos Glide!
 SBoxLimit_glide_turret=Você atingiu o limite do Armas do Glide!
 SBoxLimit_glide_missile_launcher=Você atingiu o limite de Lança-mísseis do Glide!
 SBoxLimit_glide_projectile_launcher=Você atingiu o limite de Lança-projéteis do Glide!
+
+Cleanup_glide_vehicles=Glide veículos
+Cleanup_glide_standalone_turrets=Glide Armas
+Cleanup_glide_missile_launchers=Glide Lança-mísseis
+Cleanup_glide_projectile_launchers=Glide Lança-projéteis

--- a/resource/localization/ru/glide_vehicles.properties
+++ b/resource/localization/ru/glide_vehicles.properties
@@ -369,3 +369,8 @@ SBoxLimit_glide_vehicles=Вы достигли предела Транспорт
 SBoxLimit_glide_turret=Вы достигли предела Турелей Glide!
 SBoxLimit_glide_missile_launcher=Вы достигли предела Ракетных установок Glide!
 SBoxLimit_glide_projectile_launcher=Вы достигли предела Пусковых установок Glide!
+
+Cleanup_glide_vehicles=Glide Транспорт
+Cleanup_glide_standalone_turrets=Glide Турели
+Cleanup_glide_missile_launchers=Glide Ракетные установки
+Cleanup_glide_projectile_launchers=Glide Пусковые установки

--- a/resource/localization/tr/glide_vehicles.properties
+++ b/resource/localization/tr/glide_vehicles.properties
@@ -369,3 +369,8 @@ SBoxLimit_glide_vehicles=Glide araç sınırına ulaştın!
 SBoxLimit_glide_turret=Glide Tareti sınırına ulaştın!
 SBoxLimit_glide_missile_launcher=Glide Füze Fırlatıcı sınırına ulaştın!
 SBoxLimit_glide_projectile_launcher=Glide Roketatar sınırına ulaştın!
+
+Cleanup_glide_vehicles=Glide araç
+Cleanup_glide_standalone_turrets=Glide Tareti
+Cleanup_glide_missile_launchers=Glide Füze Fırlatıcı
+Cleanup_glide_projectile_launchers=Glide Roketatar

--- a/resource/localization/uk/glide_vehicles.properties
+++ b/resource/localization/uk/glide_vehicles.properties
@@ -369,3 +369,8 @@ SBoxLimit_glide_vehicles=Ви досягли ліміту транспорту G
 SBoxLimit_glide_turret=Ви досягли ліміту турелей Glide!
 SBoxLimit_glide_missile_launcher=Ви досягли ліміту ракетних установок Glide!
 SBoxLimit_glide_projectile_launcher=Ви досягли ліміту пускових установок Glide!
+
+Cleanup_glide_vehicles=Glide Транспорт
+Cleanup_glide_standalone_turrets=Glide турелі
+Cleanup_glide_missile_launchers=Glide ракетні установки
+Cleanup_glide_projectile_launchers=Glide пускові установки

--- a/resource/localization/zh-cn/glide_vehicles.properties
+++ b/resource/localization/zh-cn/glide_vehicles.properties
@@ -368,3 +368,8 @@ SBoxLimit_glide_vehicles=你已到达了 Glide 载具限制!
 SBoxLimit_glide_turret=你已到达了 Glide 炮台限制!
 SBoxLimit_glide_missile_launcher=你已到达了 Glide 导弹发射器限制!
 SBoxLimit_glide_projectile_launcher=你已到达了 Glide 炮弹发射器限制!
+
+Cleanup_glide_vehicles=Glide 载具
+Cleanup_glide_standalone_turrets=Glide 炮台
+Cleanup_glide_missile_launchers=Glide 导弹发射器
+Cleanup_glide_projectile_launchers=Glide 炮弹发射器

--- a/resource/localization/zh-cn/glide_vehicles.properties
+++ b/resource/localization/zh-cn/glide_vehicles.properties
@@ -270,6 +270,7 @@ tool.glide_engine_stream.left=应用引擎气流预设
 tool.glide_engine_stream.right=打开引擎气流编辑器
 tool.glide_engine_stream.reload=重置引擎气流预设
 tool.glide_engine_stream.no_data=暂未有被加载的预设! 在引擎气流编辑器内打开一个新的标签
+
 tool.glide_material.name=载具材质
 tool.glide_material.desc=改变Glide载具的涂装材质
 tool.glide_material.left=设置涂装材质

--- a/resource/localization/zh-tw/glide_vehicles.properties
+++ b/resource/localization/zh-tw/glide_vehicles.properties
@@ -368,3 +368,8 @@ SBoxLimit_glide_vehicles=已達Glide載具數量限制！
 SBoxLimit_glide_turret=已達Glide砲塔數量限制！
 SBoxLimit_glide_missile_launcher=已達Glide飛彈發射器數量限制！
 SBoxLimit_glide_projectile_launcher=已達Glide砲彈發射器數量限制！
+
+Cleanup_glide_vehicles=Glide Vehicles
+Cleanup_glide_standalone_turrets=Glide Standalone Turrets
+Cleanup_glide_missile_launchers=Glide Missile Launchers
+Cleanup_glide_projectile_launchers=Glide Projectile Launchers

--- a/resource/localization/zh-tw/glide_vehicles.properties
+++ b/resource/localization/zh-tw/glide_vehicles.properties
@@ -270,6 +270,7 @@ tool.glide_engine_stream.left=套用引擎氣流預設
 tool.glide_engine_stream.right=開啟引擎氣流編輯器
 tool.glide_engine_stream.reload=重設引擎氣流預設
 tool.glide_engine_stream.no_data=暫無載入的預設！請在引擎氣流編輯器中開啟新標籤頁
+
 tool.glide_material.name=載具材質
 tool.glide_material.desc=變更Glide載具的塗裝材質
 tool.glide_material.left=設定塗裝材質


### PR DESCRIPTION
## Changes
- Added missing `Cleanup_*` strings
- Added missing `glide.camera.fixed.disabled` string in French localization
- Made Chinese localization same line-alignment as other files

Also, I don't know how to properly translate it in Chinese, Taiwan (_well, like most of other languages too_)
@HJnoJJ, we need your help here! 😊

And, there are also `Cleaned_*` strings. They're optional as gmod handle them didn't exists by replacing with 
`hint.cleanedX` = "Cleaned up all [entity class]"
So I didn't add them for this PR