### PR TITLE
Disable gravgun punt

### DIFF
--- a/lua/entities/base_glide/shared.lua
+++ b/lua/entities/base_glide/shared.lua
@@ -105,6 +105,10 @@ function ENT:GravGunPickupAllowed( _ply )
     return false
 end
 
+function ENT:GravGunPunt( _ply )
+    return false
+end
+
 -- You can safely override these on children classes
 function ENT:IsEngineOn()
     return self:GetEngineState() > 1


### PR DESCRIPTION
Disables gravgun punting on vehicles by default as it flings most vehicles unrealistically far and is a major complaint/annoyance in multiplayer.