### PR TITLE
Refactor camera logic

### DIFF
--- a/lua/autorun/sh_glide.lua
+++ b/lua/autorun/sh_glide.lua
@@ -329,6 +329,9 @@ if SERVER then
 end
 
 if CLIENT then
+    -- Make this table available before we load everything
+    Glide.Config = Glide.Config or {}
+
     -- Shared files
     Glide.IncludeDir( "glide/", true, false )
 

--- a/lua/autorun/sh_glide.lua
+++ b/lua/autorun/sh_glide.lua
@@ -329,8 +329,9 @@ if SERVER then
 end
 
 if CLIENT then
-    -- Make this table available before we load everything
+    -- Make these tables are available before we load everything
     Glide.Config = Glide.Config or {}
+    Glide.Camera = Glide.Camera or {}
 
     -- Shared files
     Glide.IncludeDir( "glide/", true, false )

--- a/lua/entities/base_glide_tank/cl_init.lua
+++ b/lua/entities/base_glide_tank/cl_init.lua
@@ -156,9 +156,6 @@ function ENT:OnUpdateMisc()
 end
 
 do
-    local Camera = Glide.Camera
-    local DrawWeaponCrosshair = Glide.DrawWeaponCrosshair
-
     local SetColor = surface.SetDrawColor
     local SetMaterial = surface.SetMaterial
     local DrawTexturedRectRotated = surface.DrawTexturedRectRotated
@@ -170,13 +167,18 @@ do
 
     local matBody = Material( "materials/glide/tank_body.png", "smooth" )
     local matTurret = Material( "materials/glide/tank_turret.png", "smooth" )
+
+    local Camera = Glide.Camera
     local CanUseWeaponry = Glide.CanUseWeaponry
+    local DrawWeaponCrosshair = Glide.DrawWeaponCrosshair
 
     --- Override this base class function.
     function ENT:DrawVehicleHUD( screenW, screenH )
         BaseClass.DrawVehicleHUD( self, screenW, screenH )
 
-        if CanUseWeaponry( LocalPlayer() ) then
+        local user = LocalPlayer()
+
+        if CanUseWeaponry( user ) then
             DrawWeaponCrosshair( screenW * 0.5, screenH * 0.5, "glide/aim_tank.png", 0.14, crosshairColor[self:GetIsAimingAtTarget()] )
         end
 

--- a/lua/glide/client/camera.lua
+++ b/lua/glide/client/camera.lua
@@ -1,96 +1,67 @@
-local Camera = Glide.Camera or {}
+local Camera = Glide.Camera
 
-Glide.Camera = Camera
-
-hook.Add( "Glide_OnLocalEnterVehicle", "Glide.ActivateCamera", function( vehicle, seatIndex )
-    Camera:Activate( vehicle, seatIndex )
-end )
-
-hook.Add( "Glide_OnLocalExitVehicle", "Glide.DeactivateCamera", function()
-    Camera:Deactivate()
-end )
-
-Camera.lastAimEntity = NULL
+Camera.hooks = Camera.hooks or {}
+Camera.isInFirstPerson = Camera.isInFirstPerson == true
 Camera.lastAimPos = Vector()
-
-Camera.viewAngles = Angle()
-Camera.isInFirstPerson = false
-Camera.FIRST_PERSON_DSP = 30
 
 function Glide.GetCameraAimPos()
     return Camera.lastAimPos
 end
 
-local Config = Glide.Config
+hook.Add( "Glide_OnLocalEnterVehicle", "Glide.SetupCamera", function( vehicle, seatIndex )
+    Camera:Initialize( LocalPlayer(), vehicle, seatIndex )
+end )
 
-function Camera:Activate( vehicle, seatIndex )
-    Config = Glide.Config
+hook.Add( "Glide_OnLocalExitVehicle", "Glide.ShutdownCamera", function()
+    Camera:Shutdown()
+end )
 
-    self.user = LocalPlayer()
+local function AddHook( name, priority )
+    local id = "GlideCamera_" .. name
+    Camera.hooks[id] = name
+
+    hook.Add( name, id, function( a, b, c )
+        return Camera[name]( Camera, a, b, c )
+    end, priority )
+end
+
+function Camera:Initialize( user, vehicle, seatIndex )
+    self.user = user
     self.vehicle = vehicle
     self.seatIndex = seatIndex
 
     self.fov = 80
-    self.origin = Vector()
-    self.angles = vehicle:GetAngles()
+    self.position = Vector()
+    self.angles = self.vehicle:GetAngles()
 
+    self.mode = 0
     self.isActive = false
     self.isUsingDirectMouse = false
     self.allowRolling = false
-
     self.centerStrength = 0
     self.lastMouseMoveTime = 0
-    self.traceFraction = 1
-    self.trailerFraction = 0
+
+    self.distanceFraction = 1
+    self.trailerDistanceFraction = 0
 
     self.punchAngle = Angle()
     self.punchVelocity = Angle()
     self.shakeOffset = Vector()
 
+    self.lastAimEntity = NULL
+    self.lastAimPosAnglesFromEyes = Angle()
+    self.lastAimPosDistanceFromEyes = 0
+
     self:SetFirstPerson( self.isInFirstPerson )
 
-    hook.Add( "Think", "GlideCamera.Think", function()
-        if self.isActive then return self:Think() end
-    end )
-
-    hook.Add( "CalcView", "GlideCamera.CalcView", function()
-        if self.isActive then return self:CalcView() end
-    end, HOOK_HIGH )
-
-    hook.Add( "CreateMove", "GlideCamera.CreateMove", function( cmd )
-        if self.isActive then return self:CreateMove( cmd ) end
-    end, HOOK_HIGH )
-
-    hook.Add( "InputMouseApply", "GlideCamera.InputMouseApply", function( _, x, y )
-        if self.isActive then return self:InputMouseApply( x, y ) end
-    end, HOOK_HIGH )
-
-    hook.Add( "PlayerBindPress", "GlideCamera.PlayerBindPress", function( ply, bind )
-        if ply == self.user and ( bind == "+right" or bind == "+left" ) then return false end
-    end )
-
-    timer.Create( "GlideCamera.CheckState", 0.2, 0, function()
-        self.isActive = self:ShouldBeActive()
-
-        local seat = self.user:GetVehicle()
-
-        if IsValid( seat ) and not self.seat then
-            self.seat = seat
-            self.angles = seat:GetAngles() + Angle( 0, 90, 0 )
-            self.angles[3] = 0
-        end
-    end )
+    AddHook( "Think" )
+    AddHook( "CalcView", HOOK_HIGH )
+    AddHook( "CreateMove", HOOK_HIGH )
+    AddHook( "PlayerBindPress" )
+    AddHook( "InputMouseApply", HOOK_HIGH )
 end
 
-function Camera:Deactivate()
-    timer.Remove( "GlideCamera.CheckState" )
-
-    hook.Remove( "Think", "GlideCamera.Think" )
-    hook.Remove( "CalcView", "GlideCamera.CalcView" )
-    hook.Remove( "CreateMove", "GlideCamera.CreateMove" )
-    hook.Remove( "InputMouseApply", "GlideCamera.InputMouseApply" )
-    hook.Remove( "PlayerBindPress", "GlideCamera.PlayerBindPress" )
-
+function Camera:Shutdown()
     if IsValid( self.vehicle ) then
         self.vehicle.isLocalPlayerInFirstPerson = false
     end
@@ -100,29 +71,35 @@ function Camera:Deactivate()
         self.user:SetEyeAngles( Angle() )
     end
 
-    self.isActive = false
     self.user = nil
     self.vehicle = nil
     self.seatIndex = nil
-    self.seat = nil
+    self.lastAimEntity = NULL
+
+    for id, name in pairs( self.hooks ) do
+        hook.Remove( name, id )
+    end
+
+    table.Empty( self.hooks )
 end
 
-function Camera:IsFixed()
-    local fixedMode = Config.fixedCameraMode
-    if fixedMode < 1 then return false end
+function Camera:ShouldBeActive()
+    if not self.user:Alive() then
+        return false
+    end
 
-    -- Fixed on first person only
-    if fixedMode == 1 and self.isInFirstPerson then return true end
+    if self.user:GetViewEntity() ~= self.user then
+        return false
+    end
 
-    -- Fixed on third person only
-    if fixedMode == 2 and not self.isInFirstPerson then return true end
+    if pace and pace.Active then
+        return false
+    end
 
-    -- Fixed on both first and third person
-    return fixedMode > 2
+    return true
 end
 
 function Camera:SetFirstPerson( enable )
-    local angles = self.angles
     local wasFixed = self:IsFixed()
 
     self.isInFirstPerson = enable
@@ -138,38 +115,32 @@ function Camera:SetFirstPerson( enable )
 
         if self:IsFixed() ~= wasFixed then
             if wasFixed then
-                self.angles = vehicle:LocalToWorldAngles( angles )
+                self.angles = vehicle:LocalToWorldAngles( self.angles )
             else
-                self.angles = vehicle:WorldToLocalAngles( angles )
+                self.angles = vehicle:WorldToLocalAngles( self.angles )
             end
         end
     end
 
     if IsValid( self.user ) then
-        self.user:SetDSP( muffleSound and self.FIRST_PERSON_DSP or 1 )
+        self.user:SetDSP( muffleSound and 30 or 1 )
     end
 end
 
-local IsValid = IsValid
+local Config = Glide.Config
 
-function Camera:ShouldBeActive()
-    if not IsValid( self.vehicle ) then
-        return false
-    end
+function Camera:IsFixed()
+    local fixedMode = Config.fixedCameraMode
+    if fixedMode < 1 then return false end
 
-    if not self.user:Alive() then
-        return false
-    end
+    -- Fixed on first person only
+    if fixedMode == 1 and self.isInFirstPerson then return true end
 
-    if self.user:GetViewEntity() ~= self.user then
-        return false
-    end
+    -- Fixed on third person only
+    if fixedMode == 2 and not self.isInFirstPerson then return true end
 
-    if pace and pace.Active then
-        return false
-    end
-
-    return true
+    -- Fixed on both first and third person
+    return fixedMode > 2
 end
 
 local Abs = math.abs
@@ -189,19 +160,11 @@ function Camera:ViewPunch( pitch, yaw, roll )
     self.punchAngle[3] = 0
 end
 
-local RealTime = RealTime
-local FrameTime = FrameTime
-
 local Cos = math.cos
 local Clamp = math.Clamp
-local IsKeyDown = input.IsKeyDown
-
 local ExpDecay = Glide.ExpDecay
-local ExpDecayAngle = Glide.ExpDecayAngle
 
 local CAMERA_TYPE = Glide.CAMERA_TYPE
-local MOUSE_FLY_MODE = Glide.MOUSE_FLY_MODE
-local MOUSE_STEER_MODE = Glide.MOUSE_STEER_MODE
 
 function Camera:DoEffects( t, dt, speed )
     -- Update view punch
@@ -214,10 +177,10 @@ function Camera:DoEffects( t, dt, speed )
     vel[1] = ExpDecay( vel[1], 0, decay, dt )
     vel[2] = ExpDecay( vel[2], 0, decay, dt )
 
-    -- Update FOV depending on speed
+    -- Update FOV depending on user settings and speed
     speed = speed - 400
 
-    local fov = ( self.isInFirstPerson and Config.cameraFOVInternal or Config.cameraFOVExternal ) + Clamp( speed * 0.01, 0, 15 )
+    local fov = ( self.isInFirstPerson and Config.cameraFOVInternal or Config.cameraFOVExternal ) + Clamp( speed * 0.01, 0, 20 )
     local keyZoom = self.user:KeyDown( IN_ZOOM )
 
     self.fov = ExpDecay( self.fov, keyZoom and 20 or fov, keyZoom and 5 or 2, dt )
@@ -231,15 +194,23 @@ function Camera:DoEffects( t, dt, speed )
     end
 end
 
+local IsValid = IsValid
+local RealTime = RealTime
+local FrameTime = FrameTime
+
+local TraceLine = util.TraceLine
+local ExpDecayAngle = Glide.ExpDecayAngle
+
+local MOUSE_FLY_MODE = Glide.MOUSE_FLY_MODE
+local MOUSE_STEER_MODE = Glide.MOUSE_STEER_MODE
+
 function Camera:Think()
     local vehicle = self.vehicle
+    if not IsValid( vehicle ) then return end
 
-    if not IsValid( vehicle ) then
-        self:Deactivate()
-        return
-    end
+    self.isActive = self:ShouldBeActive()
+    if not self.isActive then return end
 
-    -- Toggle first person
     local isSwitchKeyDown = self.user:KeyDown( IN_DUCK ) and not vgui.CursorVisible()
 
     if self.isSwitchKeyDown ~= isSwitchKeyDown then
@@ -253,17 +224,17 @@ function Camera:Think()
     local t = RealTime()
     local dt = FrameTime()
 
-    self.traceFraction = ExpDecay( self.traceFraction, 1, 2, dt )
-    self.trailerFraction = ExpDecay( self.trailerFraction, vehicle:GetConnectedReceptacleCount() > 0 and 1 or 0, 2, dt )
+    self.distanceFraction = ExpDecay( self.distanceFraction, 1, 2, dt )
+    self.trailerDistanceFraction = ExpDecay( self.trailerDistanceFraction, vehicle:GetConnectedReceptacleCount() > 0 and 1 or 0, 2, dt )
 
-    local angles = self.angles
     local velocity = vehicle:GetVelocity()
     local speed = Abs( velocity:Length() )
     local mode = vehicle:GetCameraType( self.seatIndex )
-    local freeLook = IsKeyDown( Config.binds.general_controls.free_look )
 
     self.mode = mode
     self:DoEffects( t, dt, speed )
+
+    local freeLook = input.IsKeyDown( Config.binds.general_controls.free_look )
 
     if self:IsFixed() then
         if mode == CAMERA_TYPE.AIRCRAFT then
@@ -276,6 +247,7 @@ function Camera:Think()
         return
     end
 
+    local angles = self.angles
     local vehicleAngles = vehicle:GetAngles()
     local decay, rollDecay = 3, 3
 
@@ -315,7 +287,7 @@ function Camera:Think()
             self.allowRolling = false
 
             vehicleAngles = velocity:Angle()
-            vehicleAngles[1] = vehicleAngles[1] + 5 * self.trailerFraction
+            vehicleAngles[1] = vehicleAngles[1] + 5 * self.trailerDistanceFraction
             vehicleAngles[3] = 0
 
             -- Only make the camera angles point towards the vehicle's
@@ -348,13 +320,15 @@ function Camera:Think()
     end
 end
 
-local TraceLine = util.TraceLine
+local traceResult = {}
+local traceData = { filter = {}, output = traceResult }
 
 function Camera:CalcView()
+    if not self.isActive then return end
+
     local vehicle = self.vehicle
     if not IsValid( vehicle ) then return end
 
-    local user = self.user
     local angles = self.angles
 
     if self:IsFixed() then
@@ -369,62 +343,82 @@ function Camera:CalcView()
         angles = vehicle:LocalToWorldAngles( angles )
     end
 
+    local user = self.user
+    local offset, pivot
+
     if self.isInFirstPerson then
         local localEyePos = vehicle:WorldToLocal( user:EyePos() )
         local localPos = vehicle:GetFirstPersonOffset( self.seatIndex, localEyePos )
-        self.origin = vehicle:LocalToWorld( localPos )
+        pivot = vehicle:LocalToWorld( localPos )
+        offset = Vector()
     else
-        local fraction = self.traceFraction
-        local offset = self.shakeOffset + vehicle.CameraOffset * Vector( Config.cameraDistance, 1, Config.cameraHeight ) * fraction
-        local startPos = vehicle:LocalToWorld( vehicle.CameraCenterOffset + vehicle.CameraTrailerOffset * self.trailerFraction )
-
         angles = angles + vehicle.CameraAngleOffset
+        pivot = vehicle:LocalToWorld( vehicle.CameraCenterOffset + vehicle.CameraTrailerOffset * self.trailerDistanceFraction )
 
-        local endPos = startPos
-            + angles:Forward() * offset[1] * ( 1 + self.trailerFraction * vehicle.CameraTrailerDistanceMultiplier )
+        offset = vehicle.CameraOffset * Vector( Config.cameraDistance *
+            ( 1 + self.trailerDistanceFraction * vehicle.CameraTrailerDistanceMultiplier ), 1, Config.cameraHeight )
+
+        -- Try to make the camera stay outside of walls
+        local endPos = pivot
+            + angles:Forward() * offset[1]
             + angles:Right() * offset[2]
             + angles:Up() * offset[3]
 
-        local dir = endPos - startPos
-        dir:Normalize()
+        local offsetDir = endPos - pivot
+        local offsetLen = offsetDir:Length()
+        offsetDir:Normalize()
 
-        -- Make sure the camera stays outside of walls
-        local tr = TraceLine( {
-            start = startPos,
-            endpos = endPos + dir * 10,
-            mask = 16395 -- MASK_SOLID_BRUSHONLY
-        } )
+        traceData.start = pivot
+        traceData.endpos = endPos + offsetDir * 10
+        traceData.mask = 16395 -- MASK_SOLID_BRUSHONLY
 
-        if tr.Hit then
-            endPos = tr.HitPos - dir * 10
+        TraceLine( traceData )
 
-            if tr.Fraction < fraction then
-                self.traceFraction = tr.Fraction
+        fraction = self.distanceFraction
+
+        if traceResult.Hit then
+            fraction = ( offsetLen * traceResult.Fraction ) / offsetLen
+
+            if fraction < self.distanceFraction then
+                self.distanceFraction = fraction
             end
         end
 
-        self.origin = endPos
+        offset = self.shakeOffset + offset * fraction
     end
 
-    -- Update aim position and entity
-    local origin = self.origin
+    self.position = pivot
+        + angles:Forward() * offset[1]
+        + angles:Right() * offset[2]
+        + angles:Up() * offset[3]
 
-    local tr = TraceLine( {
-        start = origin,
-        endpos = origin + angles:Forward() * 50000,
-        filter = { user, vehicle }
-    } )
+    -- Cache the camera's aim properties.
+    -- Start the trace from the camera's pivot point,
+    -- without taking the "forward" axis into consideration.
+    traceData.mask = nil
+    traceData.start = pivot
+        + angles:Right() * offset[2]
+        + angles:Up() * offset[3]
 
-    self.lastAimEntity = tr.Entity
-    self.lastAimPos = tr.HitPos
+    traceData.endpos = traceData.start + angles:Forward() * 50000
+    traceData.filter[1] = user
+    traceData.filter[2] = vehicle
 
-    -- Make the player's EyeAngles look at the same spot as the camera
-    local aimDir = self.lastAimPos - user:EyePos()
+    TraceLine( traceData )
+
+    self.lastAimPos = traceResult.HitPos
+    self.lastAimEntity = traceResult.Entity
+
+    -- Save the aim angles and position distance
+    -- to be used on the player's CUserCmd later.
+    local aimDir = traceResult.HitPos - user:EyePos()
+    self.lastAimPosDistanceFromEyes = aimDir:Length()
+
     aimDir:Normalize()
-    self.viewAngles = aimDir:Angle()
+    self.lastAimPosAnglesFromEyes = aimDir:Angle()
 
     return {
-        origin = origin,
+        origin = self.position,
         angles = angles + self.punchAngle,
         fov = self.fov,
         drawviewer = not self.isInFirstPerson
@@ -432,14 +426,23 @@ function Camera:CalcView()
 end
 
 function Camera:CreateMove( cmd )
-    cmd:SetViewAngles( self.viewAngles )
+    if self.isActive then
+        cmd:SetViewAngles( self.lastAimPosAnglesFromEyes )
+        cmd:SetUpMove( Clamp( self.lastAimPosDistanceFromEyes, 0, 10000 ) )
+    end
 end
 
-function Camera:InputMouseApply( x, y )
-    local vehicle = self.vehicle
-    if not IsValid( vehicle ) then return end
+function Camera:PlayerBindPress( ply, bind )
+    if self.isActive and ply == self.user and ( bind == "+right" or bind == "+left" ) then
+        return false
+    end
+end
+
+function Camera:InputMouseApply( _, x, y )
+    if not self.isActive then return end
     if self.isUsingDirectMouse then return end
 
+    local vehicle = self.vehicle
     local sensitivity = Config.lookSensitivity
     local lookX = ( Config.cameraInvertX and -x or x ) * 0.05 * sensitivity
     local lookY = ( Config.cameraInvertY and -y or y ) * 0.05 * sensitivity

--- a/lua/glide/client/config.lua
+++ b/lua/glide/client/config.lua
@@ -1,6 +1,4 @@
-local Config = Glide.Config or {}
-
-Glide.Config = Config
+local Config = Glide.Config
 
 --- Reset settings to their default values.
 function Config:Reset()

--- a/lua/glide/server/input.lua
+++ b/lua/glide/server/input.lua
@@ -268,7 +268,7 @@ local function HandleMouseInput( ply, active, dt )
         if not IsValid( phys ) then return end
 
         local angVel = phys:GetAngleVelocity()
-        local targetDir = ply:GlideGetCameraAngles():Forward()
+        local targetDir = ply:GlideGetAimAngles():Forward()
 
         local pitchDrag = Clamp( angVel[2] * -0.1, -3, 3 ) * dt * 40
         local rudderDrag = Clamp( angVel[3] * 0.1, -3, 3 ) * dt * 40

--- a/lua/glide/sh_anims.lua
+++ b/lua/glide/sh_anims.lua
@@ -2,9 +2,6 @@ local IsValid = IsValid
 local LocalPlayer = LocalPlayer
 local NormalizeAngle = math.NormalizeAngle
 
-local EntityMeta = FindMetaTable( "Entity" )
-local getTable = EntityMeta.GetTable
-
 hook.Add( "UpdateAnimation", "Glide.OverridePlayerAnim", function( ply )
     local vehicle = ply:GlideGetVehicle()
     if not IsValid( vehicle ) then return end
@@ -59,14 +56,16 @@ local holdTypeSequences = {
     ["passive"] = "sit_passive"
 }
 
+local GetTable = FindMetaTable( "Entity" ).GetTable
+
 hook.Add( "CalcMainActivity", "Glide.OverridePlayerActivity", function( ply )
     local vehicle = ply:GlideGetVehicle()
 
-    local vehTbl = getTable( vehicle )
+    local vehTbl = GetTable( vehicle )
     if not vehTbl then return end
     if not vehTbl.GetPlayerSitSequence then return end
 
-    local plyTbl = getTable( ply )
+    local plyTbl = GetTable( ply )
     if plyTbl.m_bWasNoclipping then
         plyTbl.m_bWasNoclipping = nil
         ply:AnimResetGestureSlot( 6 ) -- GESTURE_SLOT_CUSTOM


### PR DESCRIPTION
Besides cleaning up the client-side camera code a bit, this PR makes `Player:GlideGetAimPos()` return the correct position that the player's client-sided camera is looking at, even if there are obstructions between the player's eye position and the aim position. That fixes these issues:

- #199
- #198
- #192
- #146

### Changelog

- Make sure `Glide.Config` and `Glide.Camera` tables exists before including all other *.lua* files
- Replaced `Player:GlideGetCameraAngles()` with `Player:GlideGetAimAngles()`
- Automatically handle removing camera hooks when it gets deactivated
- On the client's `CreateMove` hook, use `CUserCmd:SetUpMove` to send the distance from the player's eyes to the camera aim position. The server can use that distance (alongside `CUserCmd:GetViewAngles` and `Player:EyePos`) to infer the aim position without using `util.TraceLine`.
- Reuse trace data and trace result tables when performing free space/aim position calculations