### PR TITLE
Fix lua error spam

### DIFF
--- a/lua/entities/base_glide/sv_weapons.lua
+++ b/lua/entities/base_glide/sv_weapons.lua
@@ -223,7 +223,7 @@ function ENT:WeaponThink()
                 -- If the target is another type of vehicle, notify the driver
                 local ply = target:GetDriver()
 
-                if IsValid( ply ) then
+                if IsValid( ply ) and ply:IsPlayer() then
                     Glide.SendLockOnDanger( ply )
                 end
             end


### PR DESCRIPTION
This is still spam for me with error, idk how, but engine vehicles drivers can be non-players
```
- Warning! Trying to net.Send a message 'glide.command' to a non-player!
1. SendLockOnDanger - lua/glide/server/network.lua:149
 2. WeaponThink - lua/entities/base_glide/sv_weapons.lua:227
  3. <unknown> - lua/entities/base_glide/init.lua:695
```
