### PR TITLE
Set wheel radius inside params upon duplication

### DIFF
--- a/lua/entities/base_glide/init.lua
+++ b/lua/entities/base_glide/init.lua
@@ -61,7 +61,7 @@ function ENT:OnDuplicated( data )
         w = wheels[i]
 
         if IsValid( w ) and type( radius ) == "number" then
-            --w.params.radius = radius
+            w.params.radius = radius
             w:ChangeRadius( radius )
         end
     end


### PR DESCRIPTION
The following commit addresses an issue with wheels having wrong radius set when ENT::Blow is called on them if the vehicle was spawned via a Duplicator.

It is resolved by simply setting the radius key inside wheel params when OnDuplicated is called.
