### PR TITLE
Wheel touch

### DIFF
--- a/lua/entities/glide_wheel/init.lua
+++ b/lua/entities/glide_wheel/init.lua
@@ -91,10 +91,6 @@ function ENT:Initialize()
     self:SetupWheel()
 end
 
-function ENT:Touch( ent )
-   -- print( "Wheel touched:", ent:GetClass() )
-end
-
 --- Set the size, models and steering properties to use on this wheel.
 function ENT:SetupWheel( t )
     t = t or {}


### PR DESCRIPTION
The other entities couldn't retrieve the wheel because it wasn't retrieving the ‘right model’; the wheel's trigger is placed too high to be detected by a harrow, for example.

I changed this in the code and made sure that it calls [ENTITY:Touch](https://wiki.facepunch.com/gmod/ENTITY:Touch), [ENTITY:StartTouch](https://wiki.facepunch.com/gmod/ENTITY:StartTouch) and [ENTITY:EndTouch](https://wiki.facepunch.com/gmod/ENTITY:EndTouch) for the wheel and the touch for the corresponding entity. 

Example : 

https://github.com/user-attachments/assets/5abe45b6-524f-42f7-b758-36037c86c1b4

```lua
function ENT:StartTouch(eWheel)
    if eWheel:GetClass() == "glide_wheel" and not eWheel:IsBlown() then
        eWheel:Blow()
    end
end
```
