### PR TITLE
Remove standalone turret max delay

### DIFF
--- a/lua/entities/glide_standalone_turret.lua
+++ b/lua/entities/glide_standalone_turret.lua
@@ -202,7 +202,7 @@ function ENT:SetTurretDamage( damage )
 end
 
 function ENT:SetTurretDelay( delay )
-    self.turretDelay = math.Clamp( delay, cvarMinDelay and cvarMinDelay:GetFloat() or 0.02, 0.5 )
+    self.turretDelay = math.max( delay, cvarMinDelay and cvarMinDelay:GetFloat() or 0.02 )
 end
 
 function ENT:SetTurretSpread( spread )


### PR DESCRIPTION
I don't see the point in limiting it, as some players might use them to create slow rocket launchers
