### PR TITLE
WebAudio: Respect volume_sfx and support Lua defined streams

### DIFF
--- a/lua/glide/client/engine_stream.lua
+++ b/lua/glide/client/engine_stream.lua
@@ -159,14 +159,14 @@ function EngineStream:CheckWebAudioJSON()
     }
 
     -- Copy customizable parameters
-    for k, v in pairs(DEFAULT_STREAM_PARAMS) do
+    for k, v in pairs( DEFAULT_STREAM_PARAMS ) do
         if self[k] ~= v then
             data.kv[k] = self[k]
         end
     end
 
     -- Copy layer data
-    for id, layer in pairs(self.layers) do
+    for id, layer in pairs( self.layers ) do
         data.layers[id] = {
             path = layer.path,
             redline = layer.redline,
@@ -174,8 +174,9 @@ function EngineStream:CheckWebAudioJSON()
         }
     end
 
-    self.updateWebJSON = Glide.ToJSON(data, false)
+    self.updateWebJSON = Glide.ToJSON( data, false )
 end
+
 local outputs = {
     volume = 0,
     pitch = 0
@@ -275,8 +276,8 @@ function EngineStream:Play()
 
     -- Ensure WebAudio bridge has the stream data if layers were added directly
     self:CheckWebAudioJSON()
-    for _, layer in pairs(self.layers) do
-        if IsValid(layer.channel) then
+    for _, layer in pairs( self.layers ) do
+        if IsValid( layer.channel ) then
             layer.channel:Play()
         end
     end

--- a/lua/glide/client/engine_stream_webaudio.lua
+++ b/lua/glide/client/engine_stream_webaudio.lua
@@ -392,9 +392,9 @@ local JS_SET_BUS_PARAM = "manager.setBusParameter('%s', %f);"
 local JS_UPDATE_LISTENER = "manager.updateListener(%.2f, %.2f, %.2f, %.2f, %.2f, %.2f, %.2f, %.2f, %.2f);"
 local JS_UPDATE_STREAM = "manager.setStreamData('%s', %.2f, %.2f, %.2f, %.2f, %.2f, %.1f, %s);"
 
-local cvarVolume = GetConVar("volume")
-local cvarVolumeSfx = GetConVar("volume_sfx")
-local cvarMuteLoseFocus = GetConVar("snd_mute_losefocus")
+local cvarVolume = GetConVar( "volume" )
+local cvarVolumeSfx = GetConVar( "volume_sfx" )
+local cvarMuteLoseFocus = GetConVar( "snd_mute_losefocus" )
 
 local AddLine = WebAudio.AddLine
 local GetVolume = Glide.Config.GetVolume
@@ -414,9 +414,9 @@ function WebAudio:Think( dt )
         self:SetDebugValue( "room.vSize", room.vSize )
     end
 
-    local wetMultiplier = (1 - room.hSize) * (0.5 + (0.4 - room.vSize * 0.6))
+    local wetMultiplier = ( 1 - room.hSize ) * ( 0.5 + ( 0.4 - room.vSize * 0.6 ) )
     -- WebAudio bypasses Source Engine audio, so we need to apply volume convars manually
-    local preGainVolume = GetVolume("carVolume") * cvarVolume:GetFloat() * cvarVolumeSfx:GetFloat()
+    local preGainVolume = GetVolume( "carVolume" ) * cvarVolume:GetFloat() * cvarVolumeSfx:GetFloat()
 
     if cvarMuteLoseFocus:GetBool() and not system.HasFocus() then
         preGainVolume = 0


### PR DESCRIPTION
This PR fixes two bugs related to the WebAudio system:

1) WebAudio being too loud
WebAudio only used the `volume` convar, but Garry's Mod has both `volume` and `volume_sfx`. This is why it was loud for anyone who had their `volume_sfx` turned down below 1 but fine for others. Fixed by adding volume_sfx multiplier alongside volume. Both systems now sound very similar in volume (WebAudio might still sound a little bit louder at times due to added reverb + effects, but only very slightly).

2) WebAudio not working for Lua defined streams
WebAudio only created data for streams loaded via JSON, but not those defined via Lua (such as those exported via stream UI). This caused Lua defined streams to be completely silent if WebAudio was enabled. Fixed by checking for valid data on `EngineStream:Play` if WebAudio is enabled, and if we're missing valid data, we parse the Lua table instead. It could be better to do this in `WebAudio:RequestStreamCreation` instead - I only noticed after I had made this, and didn't have time to test if it would be suitable or not.
