### PR TITLE
Add input blocking mechanism for vehicle actions (Glide_VehicleInput)

### DIFF
--- a/lua/entities/base_glide/sv_input.lua
+++ b/lua/entities/base_glide/sv_input.lua
@@ -137,6 +137,9 @@ function ENT:SetInputBool( seatIndex, action, pressed )
 
     if not pressed or seatIndex > 1 then return end
 
+    local blockAction = hook.Run( "Glide_VehicleInput", self, seatIndex, action )
+    if blockAction == false then return end
+
     if action == "switch_weapon" then
         self:SelectWeaponIndex( self:GetWeaponIndex() + 1 )
 


### PR DESCRIPTION
Hello,
I noticed that it doesn't have a global hook that allows blocking certain player actions before they are performed.

I think it would be useful to add one.