### PR TITLE
Add DarkRP support for vehicle locking and switching seats

### DIFF
--- a/lua/glide/server/util.lua
+++ b/lua/glide/server/util.lua
@@ -207,14 +207,6 @@ end
 --- Check if a player can lock the vehicle by either
 --- being it's creator or being a CPPI friend of the creator.
 function Glide.CanLockVehicle( ply, vehicle )
-    if DarkRP then
-        if IsValid( ply.switchingSeats ) and ply.switchingSeats == vehicle then
-            return true
-        end
-
-        return false
-    end
-
     local creator = vehicle:GetCreator()
 
     if creator == ply then
@@ -241,6 +233,15 @@ function Glide.CanEnterLockedVehicle( ply, vehicle )
     if hook.Run( "Glide_CanEnterLockedVehicle", ply, vehicle ) == false then
         return false
     end
+
+    if DarkRP then
+        if IsValid( ply.switchingSeats ) and ply.switchingSeats == vehicle then
+            return true
+        end
+
+        return false
+    end
+
 
     return cvarAlwaysEnterLocked:GetBool() or Glide.CanLockVehicle( ply, vehicle )
 end

--- a/lua/glide/server/util.lua
+++ b/lua/glide/server/util.lua
@@ -207,6 +207,14 @@ end
 --- Check if a player can lock the vehicle by either
 --- being it's creator or being a CPPI friend of the creator.
 function Glide.CanLockVehicle( ply, vehicle )
+    if DarkRP then
+        if IsValid( ply.switchingSeats ) and ply.switchingSeats == vehicle then
+            return true
+        end
+
+        return false
+    end
+
     local creator = vehicle:GetCreator()
 
     if creator == ply then
@@ -258,11 +266,14 @@ function Glide.SwitchSeat( ply, seatIndex )
         return
     end
 
+    ply.switchingSeats = vehicle
     ply:ExitVehicle()
     ply:SetAllowWeaponsInVehicle( false )
     ply:EnterVehicle( seat )
 
     hook.Run( "Glide_PostSwitchSeat", ply, seatIndex )
+
+    ply.switchingSeats = nil
 end
 
 --- Finds and returns all human players near a certain position.


### PR DESCRIPTION
Hello,
My last pull request regarding compatibility with DarkRP (#263) was accepted. Unfortunately, the key system no longer works after the @StyledStrike has been modified.

The purpose of this pull request is to prevent even the owner in DarkRP from entering a locked vehicle.