### PR TITLE
Add vehicle check to PhysgunPickup

### DIFF
--- a/lua/glide/sh_player.lua
+++ b/lua/glide/sh_player.lua
@@ -104,22 +104,26 @@ if SERVER then
         return IsValid( vehicle )
     end
 
-    hook.Add( "PhysgunPickup", "Glide.PhysgunPickup", function( _, ent )
-        if not CheckInVehicleGlide( ent ) then return end
-
-        return false
-    end, HOOK_HIGH )
-
-    if SAM then
-        Glide._OriginalCanTarget = Glide._OriginalCanTarget or PlayerMeta.CanTarget
-        local CanTarget = Glide._OriginalCanTarget
-
-        function PlayerMeta:CanTarget( target )
-            if CheckInVehicleGlide( target ) then
-                return false
+    if sam then
+        local freeze_player = function( ply )
+            if SERVER then
+                ply:Lock()
             end
-
-            return CanTarget( self, target )
+            ply:SetMoveType( MOVETYPE_NONE )
+            ply:SetCollisionGroup( COLLISION_GROUP_WORLD )
         end
+
+        sam.hook_first( "PhysgunPickup", "SAM.CanPhysgunPlayer", function( ply, target )
+            if sam.type( target ) == "Player" and ply:HasPermission( "can_physgun_players" ) and ply:CanTarget( target ) and not CheckInVehicleGlide( target ) then
+                freeze_player( target )
+                return true
+            end
+        end )
+    else
+        hook.Add( "PhysgunPickup", "Glide.PhysgunPickup", function( _, ent )
+            if not CheckInVehicleGlide( ent ) then return end
+
+            return false
+        end, HOOK_HIGH )
     end
 end

--- a/lua/glide/sh_player.lua
+++ b/lua/glide/sh_player.lua
@@ -96,4 +96,30 @@ if SERVER then
         ply.GlideCameraAngles = angles
         ply.GlideCameraAimPos = EntEyePos( ply ) + angles:Forward() * cmd:GetUpMove()
     end, HOOK_HIGH )
+
+    local function checkInVehicle( ply )
+        if not IsValid( ply ) or not ply:IsPlayer() then return false end
+
+        local vehicle = GetNWEntity( ply, "GlideVehicle", NULL )
+        return IsValid( vehicle )
+    end
+
+    hook.Add( "PhysgunPickup", "Glide.PhysgunPickup", function( _, ent )
+        if not checkInVehicle( ent ) then return end
+
+        return false
+    end, HOOK_HIGH )
+
+    if SAM then
+        Glide._OriginalCanTarget = Glide._OriginalCanTarget or PlayerMeta.CanTarget
+        local CanTarget = Glide._OriginalCanTarget
+
+        function PlayerMeta:CanTarget( target )
+            if checkInVehicle( target ) then
+                return false
+            end
+
+            return CanTarget( self, target )
+        end
+    end
 end

--- a/lua/glide/sh_player.lua
+++ b/lua/glide/sh_player.lua
@@ -97,7 +97,7 @@ if SERVER then
         ply.GlideCameraAimPos = EntEyePos( ply ) + angles:Forward() * cmd:GetUpMove()
     end, HOOK_HIGH )
 
-    local function checkInVehicle( ply )
+    local function CheckInVehicleGlide( ply )
         if not IsValid( ply ) or not ply:IsPlayer() then return false end
 
         local vehicle = GetNWEntity( ply, "GlideVehicle", NULL )
@@ -105,7 +105,7 @@ if SERVER then
     end
 
     hook.Add( "PhysgunPickup", "Glide.PhysgunPickup", function( _, ent )
-        if not checkInVehicle( ent ) then return end
+        if not CheckInVehicleGlide( ent ) then return end
 
         return false
     end, HOOK_HIGH )
@@ -115,7 +115,7 @@ if SERVER then
         local CanTarget = Glide._OriginalCanTarget
 
         function PlayerMeta:CanTarget( target )
-            if checkInVehicle( target ) then
+            if CheckInVehicleGlide( target ) then
                 return false
             end
 


### PR DESCRIPTION
Hello,
In permission systems, it's very easy to target the player instead of the vehicle, leading to situations like this.
<img width="515" height="466" alt="image" src="https://github.com/user-attachments/assets/772ead59-21b6-436d-8532-be1d061f404a" />

The goal of this PR is to block this. I made it compatible with SAM because otherwise my system wouldn't work.
