### PR TITLE
Add the Repair Ray tool/entity

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,14 @@ A pack of content and entity classes to add cars, motorcycles, planes, helicopte
 | `glide_projectile_launcher_max_radius` `<number>` | Maximum radius from explosions created by Glide Projectile Launchers
 | `glide_projectile_launcher_max_damage` `<number>` | Maximum damage dealt by explosions from Glide Projectile Launchers
 
+### Repair Ray tool limits
+
+| Command | Description
+| ------- | -----------
+| `glide_repair_ray_max_capacity` `<number>` | Maximum amount of HP that Glide Repair Rays can hold
+| `glide_repair_ray_output_per_second` `<number>` | How fast to output HP from the Glide Repair Rays, per second
+| `glide_repair_ray_refill_per_second` `<number>` | How fast to replenish the HP of Glide Repair Rays, per second
+
 ### Ragdolls
 
 | Command | Description

--- a/lua/autorun/sh_glide.lua
+++ b/lua/autorun/sh_glide.lua
@@ -210,6 +210,7 @@ CreateConVar( "sbox_maxglide_standalone_turrets", "5", FCVAR_ARCHIVE + FCVAR_NOT
 CreateConVar( "sbox_maxglide_missile_launchers", "5", FCVAR_ARCHIVE + FCVAR_NOTIFY + FCVAR_REPLICATED, "Max. number of Glide Missile Launchers that one player can have", 0 )
 CreateConVar( "sbox_maxglide_projectile_launchers", "5", FCVAR_ARCHIVE + FCVAR_NOTIFY + FCVAR_REPLICATED, "Max. number of Glide Projectile Launchers that one player can have", 0 )
 CreateConVar( "sbox_maxglide_engine_stream_chips", "3", FCVAR_ARCHIVE + FCVAR_NOTIFY + FCVAR_REPLICATED, "Max. number of Glide Engine Stream Chips that one player can have", 0 )
+CreateConVar( "sbox_maxglide_repair_rays", "3", FCVAR_ARCHIVE + FCVAR_NOTIFY + FCVAR_REPLICATED, "Max. number of Glide Repair Rays that one player can have", 0 )
 
 -- Turret tool convars
 CreateConVar( "glide_turret_explosive_allow", "1", FCVAR_ARCHIVE + FCVAR_NOTIFY + FCVAR_REPLICATED, "Allows Glide Turrets to use explosive bullets.", 0, 1 )
@@ -227,6 +228,11 @@ CreateConVar( "glide_projectile_launcher_min_delay", "0.5", FCVAR_ARCHIVE + FCVA
 CreateConVar( "glide_projectile_launcher_max_lifetime", "10", FCVAR_ARCHIVE + FCVAR_NOTIFY + FCVAR_REPLICATED, "Maximum projectile flight time allowed for Glide Projectile Launchers.", 1 )
 CreateConVar( "glide_projectile_launcher_max_radius", "500", FCVAR_ARCHIVE + FCVAR_NOTIFY + FCVAR_REPLICATED, "Maximum radius from explosions created by Glide Projectile Launchers.", 10 )
 CreateConVar( "glide_projectile_launcher_max_damage", "200", FCVAR_ARCHIVE + FCVAR_NOTIFY + FCVAR_REPLICATED, "Maximum damage dealt by explosions from Glide Projectile Launchers.", 1 )
+
+-- Repair Ray tool convars
+CreateConVar( "glide_repair_ray_max_capacity", "600", FCVAR_ARCHIVE + FCVAR_NOTIFY + FCVAR_REPLICATED, "Maximum amount of HP that Glide Repair Rays can hold.", 1, 10000 )
+CreateConVar( "glide_repair_ray_output_per_second", "50", FCVAR_ARCHIVE + FCVAR_NOTIFY + FCVAR_REPLICATED, "How fast to output HP from the Glide Repair Rays, per second.", 1, 1000 )
+CreateConVar( "glide_repair_ray_refill_per_second", "10", FCVAR_ARCHIVE + FCVAR_NOTIFY + FCVAR_REPLICATED, "How fast to replenish the HP of Glide Repair Rays, per second.", 1, 1000 )
 
 -- Gib convars
 CreateConVar( "glide_gib_lifetime", "8", FCVAR_ARCHIVE + FCVAR_NOTIFY + FCVAR_REPLICATED, "Lifetime of Glide Gibs, 0 for no despawning.", 0 )

--- a/lua/entities/glide_missile_launcher.lua
+++ b/lua/entities/glide_missile_launcher.lua
@@ -31,7 +31,8 @@ end
 function ENT:PostEntityPaste( ply, ent, createdEntities )
     Glide.PostEntityPaste( ply, ent, createdEntities )
 
-    -- Update parameters in case the limits/console variables are not set to default
+    -- Update parameters in case the limits/console variables
+    -- are different compared to when this entity was duped.
     self:SetReloadDelay( self.reloadDelay )
     self:SetMissileLifetime( self.missileLifetime )
     self:SetExplosionRadius( self.explosionRadius )

--- a/lua/entities/glide_projectile_launcher.lua
+++ b/lua/entities/glide_projectile_launcher.lua
@@ -34,7 +34,8 @@ end
 function ENT:PostEntityPaste( ply, ent, createdEntities )
     Glide.PostEntityPaste( ply, ent, createdEntities )
 
-    -- Update parameters in case the limits/console variables are not set to default
+    -- Update parameters in case the limits/console variables
+    -- are different compared to when this entity was duped.
     self:SetProjectileSpeed( self.projectileSpeed )
     self:SetProjectileGravity( self.projectileGravity )
     self:SetProjectileLifetime( self.projectileLifetime )

--- a/lua/entities/glide_repair_ray.lua
+++ b/lua/entities/glide_repair_ray.lua
@@ -1,0 +1,205 @@
+AddCSLuaFile()
+
+ENT.Type = "anim"
+ENT.Base = "base_anim"
+ENT.PrintName = "#tool.glide_repair_ray.name"
+ENT.Category = "Glide"
+
+ENT.Spawnable = false
+ENT.AdminOnly = false
+ENT.AutomaticFrameAdvance = true
+ENT.RenderGroup = RENDERGROUP_TRANSLUCENT
+
+function ENT:SetupDataTables()
+    self:NetworkVar( "Float", "RepairCapacity" )
+    self:NetworkVar( "Float", "RepairDistance" )
+end
+
+do
+    local ray = {}
+
+    local traceData = {
+        output = ray,
+        filter = { NULL, "player" },
+        mask = MASK_PLAYERSOLID
+    }
+
+    function ENT:GetRepairRay()
+        traceData.start = self:GetPos()
+        traceData.endpos = traceData.start + self:GetUp() * self:GetRepairDistance()
+        traceData.filter[1] = self
+
+        util.TraceLine( traceData )
+
+        return ray
+    end
+end
+
+local cvarMaxCapacity = GetConVar( "glide_repair_ray_max_capacity" )
+
+if CLIENT then
+    function ENT:Initialize()
+        self:SetRenderBounds( Vector( -10, -10, -10 ), Vector( 10, 10, 600 ) )
+    end
+
+    local matBeam = Material( "tripmine_laser" )
+    local strInfo = "%s\n%d / %d"
+
+    function ENT:Draw()
+        self:DrawModel()
+
+        local ply = LocalPlayer()
+        local myPos = self:GetPos()
+
+        if myPos:DistToSqr( ply:GetPos() ) < 500000 then
+            local ray = self:GetRepairRay()
+
+            render.SetMaterial( matBeam )
+            render.DrawBeam( myPos, ray.HitPos, 6, 0, 10, self:GetColor() )
+
+            if ply:GetEyeTrace().Entity == self then
+                AddWorldTip( nil, string.format( strInfo, language.GetPhrase( "tool.glide_repair_ray.name" ),
+                    self:GetRepairCapacity(), cvarMaxCapacity:GetInt() ), nil, myPos, nil )
+            end
+        end
+    end
+end
+
+if not SERVER then return end
+
+function ENT:OnEntityCopyTableFinish( data )
+    Glide.FilterEntityCopyTable( data, {
+        RepairDistance = true -- Only save this
+    } )
+end
+
+function ENT:PreEntityCopy()
+    Glide.PreEntityCopy( self )
+end
+
+function ENT:PostEntityPaste( ply, ent, createdEntities )
+    Glide.PostEntityPaste( ply, ent, createdEntities )
+end
+
+local function MakeSpawner( ply, data )
+    if IsValid( ply ) and not ply:CheckLimit( "glide_repair_rays" ) then return end
+
+    local ent = ents.Create( data.Class )
+    if not IsValid( ent ) then return end
+
+    ent:SetPos( data.Pos )
+    ent:SetAngles( data.Angle )
+    ent:SetCreator( ply )
+    ent:Spawn()
+    ent:Activate()
+
+    ply:AddCount( "glide_repair_rays", ent )
+    cleanup.Add( ply, "glide_repair_rays", ent )
+
+    return ent
+end
+
+duplicator.RegisterEntityClass( "glide_repair_ray", MakeSpawner, "Data" )
+
+function ENT:SpawnFunction( ply, tr )
+    if tr.Hit then
+        return MakeSpawner( ply, {
+            Pos = tr.HitPos,
+            Angle = Angle(),
+            Class = self.ClassName
+        } )
+    end
+end
+
+function ENT:Initialize()
+    self:SetModel( "models/props_junk/PopCan01a.mdl" )
+    self:SetSolid( SOLID_VPHYSICS )
+    self:SetMoveType( MOVETYPE_VPHYSICS )
+    self:PhysicsInit( SOLID_VPHYSICS )
+    self:SetCollisionGroup( COLLISION_GROUP_WEAPON )
+    self:DrawShadow( false )
+
+    self.isActive = false
+    self.lastThinkT = CurTime()
+
+    self:SetRepairCapacity( 0 )
+    self:SetRepairDistance( 100 )
+
+    if WireLib then
+        WireLib.CreateSpecialInputs( self,
+            { "Activate", "Distance" },
+            { "NORMAL", "NORMAL" }
+        )
+
+        WireLib.CreateSpecialOutputs( self, { "Capacity" }, { "NORMAL" } )
+    end
+end
+
+local CurTime = CurTime
+local TriggerOutput = WireLib and WireLib.TriggerOutput or nil
+
+local cvarRefillSpeed = GetConVar( "glide_repair_ray_refill_per_second" )
+local cvarOutputSpeed = GetConVar( "glide_repair_ray_output_per_second" )
+
+function ENT:Think()
+    local t = CurTime()
+    local dt = t - self.lastThinkT
+
+    self.lastThinkT = t
+
+    local repairCapacity = self:GetRepairCapacity()
+
+    if TriggerOutput then
+        TriggerOutput( self, "Capacity", repairCapacity )
+    end
+
+    local wasHealthIncreased, hasFinished = false, false
+
+    if self.isActive and repairCapacity > 0 then
+        local ray = self:GetRepairRay()
+        local ent = ray.Entity
+
+        if IsValid( ent ) and ent.IsGlideVehicle and ent:WaterLevel() < 3 then
+            local repairAmount = math.Clamp( cvarOutputSpeed:GetInt() * dt, 0, repairCapacity )
+
+            wasHealthIncreased, hasFinished = Glide.PartialRepair( ent, repairAmount, repairAmount * 0.002 )
+
+            if wasHealthIncreased then
+                repairCapacity = repairCapacity - repairAmount
+                self:SetRepairCapacity( repairCapacity )
+            end
+
+            if hasFinished then
+                self:EmitSound( "buttons/lever6.wav", 75, math.random( 70, 80 ), 0.8 )
+
+            elseif wasHealthIncreased then
+                self:EmitSound( ( "glide/train/track_clank_%d.wav" ):format( math.random( 6 ) ), 75, 150, 0.4 )
+
+                local data = EffectData()
+                data:SetOrigin( ray.HitPos + ray.HitNormal * 5 )
+                data:SetNormal( ray.HitNormal )
+                data:SetScale( 1 )
+                data:SetMagnitude( 1 )
+                data:SetRadius( 10 )
+                util.Effect( "cball_bounce", data, false, true )
+            end
+        end
+    end
+
+    if not wasHealthIncreased then
+        self:SetRepairCapacity( math.Clamp( repairCapacity + cvarRefillSpeed:GetInt() * dt, 0, cvarMaxCapacity:GetInt() ) )
+    end
+
+    self:NextThink( t + 0.1 )
+
+    return true
+end
+
+function ENT:TriggerInput( name, value )
+    if name == "Activate" then
+        self.isActive = value > 0
+
+    elseif name == "Distance" then
+        self:SetRepairDistance( math.Clamp( value, 10, 200 ) )
+    end
+end

--- a/lua/entities/glide_standalone_turret.lua
+++ b/lua/entities/glide_standalone_turret.lua
@@ -90,7 +90,8 @@ end
 function ENT:PostEntityPaste( ply, ent, createdEntities )
     Glide.PostEntityPaste( ply, ent, createdEntities )
 
-    -- Update parameters in case the limits/console variables are not set to default
+    -- Update parameters in case the limits/console variables
+    -- are different compared to when this entity was duped.
     self:SetTurretExplosive( self.isExplosive )
     self:SetTurretDamage( self.turretDamage )
     self:SetTurretDelay( self.turretDelay )

--- a/lua/glide/client/config.lua
+++ b/lua/glide/client/config.lua
@@ -1092,6 +1092,11 @@ function Config:OpenFrame()
             { name = "glide_projectile_launcher_max_lifetime", decimals = 1, min = 1, max = 30 },
             { name = "glide_projectile_launcher_max_radius", decimals = 0, min = 10, max = 1000 },
             { name = "glide_projectile_launcher_max_damage", decimals = 0, min = 0, max = 1000 },
+
+            { category = "#tool.glide_repair_ray.name" },
+            { name = "glide_repair_ray_max_capacity", decimals = 0, min = 1, max = 10000 },
+            { name = "glide_repair_ray_output_per_second", decimals = 0, min = 1, max = 1000 },
+            { name = "glide_repair_ray_refill_per_second", decimals = 0, min = 1, max = 1000 },
         }
 
         for _, data in ipairs( cvarList ) do

--- a/lua/weapons/glide_instant_repair.lua
+++ b/lua/weapons/glide_instant_repair.lua
@@ -25,7 +25,7 @@ function SWEP:PrimaryAttack()
     local ent = self.repairTarget
     if not ent then return end
 
-    local wasHealthIncreased, hasFinished = Glide.PartialRepair( ent, 99999, 1.0, user )
+    local wasHealthIncreased, hasFinished = Glide.PartialRepair( ent, 99999, 1.0 )
 
     if wasHealthIncreased then
         if user.ViewPunch then

--- a/lua/weapons/glide_repair.lua
+++ b/lua/weapons/glide_repair.lua
@@ -92,7 +92,7 @@ function SWEP:PrimaryAttack()
     if not ent then return end
 
     local repairMul = repairSpeedMulCvar:GetFloat()
-    local wasHealthIncreased, hasFinished = Glide.PartialRepair( ent, 20 * repairMul, 0.03 * repairMul, user )
+    local wasHealthIncreased, hasFinished = Glide.PartialRepair( ent, 20 * repairMul, 0.03 * repairMul )
 
     if wasHealthIncreased then
         user:EmitSound( ( "glide/train/track_clank_%d.wav" ):format( math.random( 6 ) ), 75, 150, 0.2 )

--- a/lua/weapons/gmod_tool/stools/glide_repair_ray.lua
+++ b/lua/weapons/gmod_tool/stools/glide_repair_ray.lua
@@ -1,0 +1,88 @@
+TOOL.Category = "Glide"
+TOOL.Name = "#tool.glide_repair_ray.name"
+
+TOOL.Information = {
+    { name = "left" },
+    { name = "right" }
+}
+
+TOOL.ClientConVar = {
+    distance = 50,
+}
+
+local function IsGlideRepairRay( ent )
+    return IsValid( ent ) and ent:GetClass() == "glide_repair_ray"
+end
+
+if SERVER then
+    function TOOL:Deploy()
+        Glide.ToolCheckMissingWiremod( self:GetOwner() )
+    end
+
+    function TOOL:UpdateRepairRay( ent )
+        ent:TriggerInput( "Distance", self:GetClientNumber( "distance" ) )
+    end
+end
+
+function TOOL:LeftClick( trace )
+    local ent = trace.Entity
+
+    if IsGlideRepairRay( ent ) then
+        if SERVER then
+            self:UpdateRepairRay( ent )
+        end
+
+        return true
+    end
+
+    local ply = self:GetOwner()
+
+    if not ply:CheckLimit( "glide_repair_rays" ) then
+        return false
+    end
+
+    if SERVER then
+        local normal = trace.HitNormal
+        local pos = trace.HitPos + normal * 5
+
+        ent = duplicator.CreateEntityFromTable( ply, {
+            Class = "glide_repair_ray",
+            Pos = pos,
+            Angle = normal:Angle() + Angle( 90, 0, 0 )
+        } )
+
+        if not IsValid( ent ) then return false end
+
+        undo.Create( self.Name )
+        undo.AddEntity( ent )
+        undo.SetPlayer( ply )
+        undo.Finish()
+
+        self:UpdateRepairRay( ent )
+    end
+
+    return true
+end
+
+function TOOL:RightClick( trace )
+    local ent = trace.Entity
+    if not IsGlideRepairRay( ent ) then return false end
+
+    if SERVER then
+        self:GetOwner():ConCommand( "glide_repair_ray_distance " .. ent:GetRepairDistance() )
+    end
+
+    return true
+end
+
+function TOOL.BuildCPanel( panel )
+    panel:Help( "#tool.glide_repair_ray.desc" )
+
+    panel:AddControl( "slider", {
+        Label = "#tool.lamp.distance",
+        command = "glide_repair_ray_distance",
+        type = "float",
+        min = 10,
+        max = 200
+    } )
+end

--- a/resource/localization/en/glide_vehicles.properties
+++ b/resource/localization/en/glide_vehicles.properties
@@ -345,6 +345,11 @@ tool.glide_projectile_launcher.smoke_color=Smoke color
 tool.glide_projectile_launcher.projectile_model=Projectile model
 tool.glide_projectile_launcher.projectile_model_scale=Projectile scale
 
+tool.glide_repair_ray.name=Repair Ray
+tool.glide_repair_ray.desc=Gradually repairs the vehicle that the ray is pointing at
+tool.glide_repair_ray.left=Spawn/update Repair Ray
+tool.glide_repair_ray.right=Copy settings from another Repair Ray
+
 tool.glide_water_driving.name=Water Driving
 tool.glide_water_driving.desc=Allows Glide vehicles with wheels to drive over water
 tool.glide_water_driving.left=Make a vehicle drivable over water

--- a/resource/localization/es-es/glide_vehicles.properties
+++ b/resource/localization/es-es/glide_vehicles.properties
@@ -346,6 +346,11 @@ tool.glide_projectile_launcher.smoke_color=Color del humo
 tool.glide_projectile_launcher.projectile_model=Modelo de proyectil
 tool.glide_projectile_launcher.projectile_model_scale=Escala de proyectil
 
+tool.glide_repair_ray.name=Rayo de reparación
+tool.glide_repair_ray.desc=Repara gradualmente el vehículo al que apunta el rayo
+tool.glide_repair_ray.left=Generar/actualizar rayo de reparación
+tool.glide_repair_ray.right=Copiar la configuración de otro rayo de reparación
+
 tool.glide_water_driving.name=Conducción sobre agua
 tool.glide_water_driving.desc=Permite que los vehículos Glide con ruedas conduzcan sobre el agua
 tool.glide_water_driving.left=Hacer que un vehículo sea conducible sobre el agua

--- a/resource/localization/fr/glide_vehicles.properties
+++ b/resource/localization/fr/glide_vehicles.properties
@@ -346,6 +346,11 @@ tool.glide_projectile_launcher.smoke_color=Couleur de la fumée
 tool.glide_projectile_launcher.projectile_model=Modèle de projectile
 tool.glide_projectile_launcher.projectile_model_scale=Échelle du projectile
 
+tool.glide_repair_ray.name=Rayon de réparation
+tool.glide_repair_ray.desc=Répare progressivement le véhicule ciblé par le rayon
+tool.glide_repair_ray.left=Faire apparaître/mettre à jour le rayon de réparation
+tool.glide_repair_ray.right=Copier les paramètres d'un autre rayon de réparation
+
 tool.glide_water_driving.name=Conduite sur l'eau
 tool.glide_water_driving.desc=Permet aux véhicules Glide avec roues de rouler sur l'eau
 tool.glide_water_driving.left=Permettre à un véhicule de rouler sur l'eau

--- a/resource/localization/pt-br/glide_vehicles.properties
+++ b/resource/localization/pt-br/glide_vehicles.properties
@@ -346,6 +346,11 @@ tool.glide_projectile_launcher.smoke_color=Cor da fumaça
 tool.glide_projectile_launcher.projectile_model=Modelo de projétil
 tool.glide_projectile_launcher.projectile_model_scale=Escala do projétil
 
+tool.glide_repair_ray.name=Raio de Reparo
+tool.glide_repair_ray.desc=Repara gradualmente o veículo para o qual o raio está apontando
+tool.glide_repair_ray.left=Gerar/atualizar Raio de Reparo
+tool.glide_repair_ray.right=Copiar configurações de outro Raio de Reparo
+
 tool.glide_water_driving.name=Dirigir Na Água
 tool.glide_water_driving.desc=Permite que veículos Glide vehicles dirijam sobre a água
 tool.glide_water_driving.left=Fazer veículo dirijível sobre a água

--- a/resource/localization/ru/glide_vehicles.properties
+++ b/resource/localization/ru/glide_vehicles.properties
@@ -346,6 +346,11 @@ tool.glide_projectile_launcher.smoke_color=Цвет дыма
 tool.glide_projectile_launcher.projectile_model=Модель снаряда
 tool.glide_projectile_launcher.projectile_model_scale=Масштаб снаряда
 
+tool.glide_repair_ray.name=Ремонтный луч
+tool.glide_repair_ray.desc=Постепенно ремонтирует транспортное средство, на которое направлен луч
+tool.glide_repair_ray.left=Создать/обновить ремонтный луч
+tool.glide_repair_ray.right=Скопировать настройки из другого ремонтного луча
+
 tool.glide_water_driving.name=Езда по воде
 tool.glide_water_driving.desc=Позволяет транспорту Glide с колёсами ездить по воде
 tool.glide_water_driving.left=Сделать транспорт пригодным для езды по воде

--- a/resource/localization/tr/glide_vehicles.properties
+++ b/resource/localization/tr/glide_vehicles.properties
@@ -346,6 +346,11 @@ tool.glide_projectile_launcher.smoke_color=Duman rengi
 tool.glide_projectile_launcher.projectile_model=Mermi modeli
 tool.glide_projectile_launcher.projectile_model_scale=Mermi ölçeği
 
+tool.glide_repair_ray.name=Onarım Işını
+tool.glide_repair_ray.desc=Işının işaret ettiği aracı kademeli olarak onarır
+tool.glide_repair_ray.left=Onarım Işını Oluştur/Güncelle
+tool.glide_repair_ray.right=Başka bir Onarım Işınından ayarları kopyala
+
 tool.glide_water_driving.name=Suda Sürüş
 tool.glide_water_driving.desc=Tekerlekli Glide araçlarının su üzerinde sürmesine izin verir
 tool.glide_water_driving.left=Bir aracı su üzerinde sürülebilir hale getir

--- a/resource/localization/uk/glide_vehicles.properties
+++ b/resource/localization/uk/glide_vehicles.properties
@@ -346,6 +346,11 @@ tool.glide_projectile_launcher.smoke_color=Колір диму
 tool.glide_projectile_launcher.projectile_model=Модель снаряда
 tool.glide_projectile_launcher.projectile_model_scale=Масштаб снаряда
 
+tool.glide_repair_ray.name=Промінь ремонту
+tool.glide_repair_ray.desc=Поступово ремонтує транспортний засіб, на який спрямований промінь
+tool.glide_repair_ray.left=Створити/оновити промінь ремонту
+tool.glide_repair_ray.right=Копіювати налаштування з іншого променя ремонту
+
 tool.glide_water_driving.name=Їзда по Воді
 tool.glide_water_driving.desc=Дозволяє транспорту Glide з колесами пересуватися по воді
 tool.glide_water_driving.left=Робить транспортний засіб пересувним по воді

--- a/resource/localization/zh-cn/glide_vehicles.properties
+++ b/resource/localization/zh-cn/glide_vehicles.properties
@@ -346,6 +346,11 @@ tool.glide_projectile_launcher.smoke_color=烟雾颜色
 tool.glide_projectile_launcher.projectile_model=炮弹模型
 tool.glide_projectile_launcher.projectile_model_scale=炮弹模型大小
 
+tool.glide_repair_ray.name=修复射线
+tool.glide_repair_ray.desc=逐渐修复射线指向的载具
+tool.glide_repair_ray.left=生成/更新修复射线
+tool.glide_repair_ray.right=从另一个修复射线复制设置
+
 tool.glide_water_driving.name=轻车水上开
 tool.glide_water_driving.desc=允许 Glide 带轮子的载具在水上行驶
 tool.glide_water_driving.left=使载具可以在水上开

--- a/resource/localization/zh-tw/glide_vehicles.properties
+++ b/resource/localization/zh-tw/glide_vehicles.properties
@@ -346,6 +346,11 @@ tool.glide_projectile_launcher.smoke_color=煙霧顏色
 tool.glide_projectile_launcher.projectile_model=砲彈模型
 tool.glide_projectile_launcher.projectile_model_scale=砲彈模型大小
 
+tool.glide_repair_ray.name=修復射線
+tool.glide_repair_ray.desc=逐漸修復射線指向的載具
+tool.glide_repair_ray.left=產生/更新修復射線
+tool.glide_repair_ray.right=從另一個修復射線複製設置
+
 tool.glide_water_driving.name=水上駕駛模式
 tool.glide_water_driving.desc=允許Glide輪式載具在水上行駛
 tool.glide_water_driving.left=啟用載具水上駕駛


### PR DESCRIPTION
Adds a Repair Ray entity and a tool to spawn it. It's a Wiremod component to gradually repair vehicles that the ray touches. It has a limited "repair capacity", that replenishes over time.

These are the new server console variables to tweak it:

| Command | Default value | Description
| - | - | -
| `glide_repair_ray_max_capacity` | `600` | Maximum amount of HP that Glide Repair Rays can hold
| `glide_repair_ray_output_per_second` | `50` | How fast to output HP from the Glide Repair Rays, per second
| `glide_repair_ray_refill_per_second` | `10` | How fast to replenish the HP of Glide Repair Rays, per second