### PR TITLE
Moving the physics update to VariableEdited

### DIFF
--- a/lua/glide/server/events.lua
+++ b/lua/glide/server/events.lua
@@ -128,11 +128,15 @@ hook.Add( "CanEditVariable", "Glide.ValidateEditVariables", function( ent, _, _,
 
     if value < editor.min then return false end
     if value > editor.max then return false end
+end )
+
+hook.Add( "VariableEdited", "Glide.EditVariables", function( ent, _, _, _, editor )
+    if not ent.IsGlideVehicle then return end
+    if not editor.min or not editor.max then return end
 
     ent.shouldUpdateWheelParams = true
 
     local phys = ent:GetPhysicsObject()
-
     if IsValid( phys ) then
         phys:Wake()
     end


### PR DESCRIPTION
Under certain conditions, Glide `CanEditVariable` may run before the permissions hooks, which updates the vehicle's physics.

For added safety, it is best to move it to the Variable hook.