### PR TITLE
Optimized the hook that allows adding vehicles to the Glide vehicle l…

### DIFF
--- a/lua/glide/client/spawn_tab.lua
+++ b/lua/glide/client/spawn_tab.lua
@@ -1,11 +1,8 @@
 local function GetCategoryVehicles( category )
     local filtered = {}
-    local i = 0
-
     for class, data in pairs( list.Get( "GlideVehicles" ) or {} ) do
         if data.Category == category then
-            i = i + 1
-            filtered[i] = {
+            filtered[#filtered + 1] = {
                 class = class,
                 name = data.Name,
                 icon = data.IconOverride or "entities/" .. class .. ".png",

--- a/lua/glide/client/spawn_tab.lua
+++ b/lua/glide/client/spawn_tab.lua
@@ -1,27 +1,15 @@
 local function GetCategoryVehicles( category )
-    local type = type
-
-    local function Validate( t )
-        if type( t ) ~= "table" then return false end
-        if type( t.ClassName ) ~= "string" then return false end
-        if type( t.GlideCategory ) ~= "string" then return false end
-
-        return true
-    end
-
     local filtered = {}
     local i = 0
 
-    for class, data in pairs( scripted_ents.GetList() ) do
-        local t = data.t
-
-        if Validate( t ) and t.GlideCategory == category then
+    for class, data in pairs( list.Get( "GlideVehicles" ) or {} ) do
+        if data.Category == category then
             i = i + 1
             filtered[i] = {
                 class = class,
-                name = t.PrintName,
-                icon = t.IconOverride or "entities/" .. class .. ".png",
-                adminOnly = t.AdminOnly
+                name = data.Name,
+                icon = data.IconOverride or "entities/" .. class .. ".png",
+                adminOnly = data.AdminOnly
             }
         end
     end

--- a/lua/glide/sh_lists.lua
+++ b/lua/glide/sh_lists.lua
@@ -51,32 +51,33 @@ list.Set( "GlideProjectileModels", "models/props_phx/misc/potato_launcher_explos
 -- Find and register all entities that are children of `base_glide`
 -- (or any of it's children classes) on the duplicator/entity limit system.
 -- Also add them to a separate list, and make them spawnable on Starfall.
-hook.Add( "InitPostEntity", "Glide.RegisterEntityClasses", function()
+if SERVER then
     local IsBasedOn = scripted_ents.IsBasedOn
-    local RegisterEntityClass = duplicator.RegisterEntityClass
+    hook.Add( "InitPostEntity", "Glide.RegisterEntityClasses", function()
+        if SF == nil then return end
 
-    local isStarfallAvailable = SF ~= nil
-    local starfallData = { {} }
-
-    for class, data in pairs( scripted_ents.GetList() ) do
-        if IsBasedOn( class, "base_glide" ) then
-            if SERVER then
-                RegisterEntityClass( class, Glide.VehicleFactory, "Data" )
-
-                if isStarfallAvailable then
-                    list.Set( "starfall_creatable_sent", class, starfallData )
-                end
-            end
-
-            local entTable = data["t"]
-
-            if entTable and entTable.GlideCategory then
-                list.Set( "GlideVehicles", class, {
-                    Name = entTable.PrintName or class,
-                    Category = entTable.GlideCategory or "Default",
-                    Model = entTable.ChassisModel
-                } )
+        local starfallData = { {} }
+        for class, _ in pairs( scripted_ents.GetList() ) do
+            if IsBasedOn( class, "base_glide" ) then
+                list.Set( "starfall_creatable_sent", class, starfallData )
             end
         end
+    end )
+end
+
+local RegisterEntityClass = duplicator.RegisterEntityClass
+hook.Add( "PreRegisterSENT", "Glide.RegisterEntityClasses", function( tbl, class )
+    if not tbl or not class then return end
+    if not tbl.GlideCategory or tbl.GlideCategory == "" then return end
+
+    if SERVER then
+        RegisterEntityClass( class, Glide.VehicleFactory, "Data" )
     end
-end )
+
+    list.Set( "GlideVehicles", class, {
+        Name = tbl.PrintName or class,
+        Category = tbl.GlideCategory or "Default",
+        IconOverride = tbl.IconOverride,
+        Model = tbl.ChassisModel
+    } )
+end  )

--- a/lua/glide/sh_lists.lua
+++ b/lua/glide/sh_lists.lua
@@ -52,15 +52,12 @@ list.Set( "GlideProjectileModels", "models/props_phx/misc/potato_launcher_explos
 -- (or any of it's children classes) on the duplicator/entity limit system.
 -- Also add them to a separate list, and make them spawnable on Starfall.
 if SERVER then
-    local IsBasedOn = scripted_ents.IsBasedOn
     hook.Add( "InitPostEntity", "Glide.RegisterEntityClasses", function()
         if SF == nil then return end
 
         local starfallData = { {} }
-        for class, _ in pairs( scripted_ents.GetList() ) do
-            if IsBasedOn( class, "base_glide" ) then
-                list.Set( "starfall_creatable_sent", class, starfallData )
-            end
+        for class, _ in pairs( list.Get( "GlideVehicles" ) ) do
+            list.Set( "starfall_creatable_sent", class, starfallData )
         end
     end )
 end


### PR DESCRIPTION
Hello,
I've optimized the InitPostEntity hook for list `GlideVehicles`.

I've also replaced scripted_ents with the Glide list in the spawnmenu.

I haven't implemented this feature because I was unsure of its relevance. Is it better to detect SF directly in ``PreRegisterSENT`` using [file.Find](https://wiki.facepunch.com/gmod/file.Find) only once (outside the hook)?

In case of doubt, I left it in ``InitPostEntity``.