### PR TITLE
Addition of a variable specific to Glide icons

### DIFF
--- a/lua/glide/client/spawn_tab.lua
+++ b/lua/glide/client/spawn_tab.lua
@@ -28,12 +28,13 @@ local function CreateCategory( parentNode, contentPanel, name, icon, category )
         local items = GetCategoryVehicles( category )
 
         for _, v in SortedPairsByMemberValue( items, "name" ) do
-            spawnmenu.CreateContentIcon( "entity", s.itemsPanel, {
+            local iconSpawnMenu = spawnmenu.CreateContentIcon( "entity", s.itemsPanel, {
                 nicename = v.name or v.class,
                 spawnname = v.class,
                 material = v.icon or icon or "icon16/car.png",
                 admin = v.adminOnly
             } )
+            iconSpawnMenu.bIsGlide = true
         end
     end
 


### PR DESCRIPTION
Hello,
I’ve added a variable to distinguish "glide" spawnmenu icons from the rest. Since [GetContentType](https://wiki.facepunch.com/gmod/spawnmenu.GetContentType) can't be used (as it's intended for entities), I thought it would be useful to have a variable that identifies a glide icon.

This is particularly useful for the [SpawnmenuIconMenuOpen](https://wiki.facepunch.com/gmod/SANDBOX:SpawnmenuIconMenuOpen) hook.

