### PR TITLE
Change of the default value for MaxVelocity

### DIFF
--- a/lua/glide/server/events.lua
+++ b/lua/glide/server/events.lua
@@ -225,7 +225,7 @@ do
     -- Make sure some physics performance settings are
     -- at least equal to or higher than these values.
     local minimumValues = {
-        MaxVelocity = 2000,
+        MaxVelocity = 4000,
         MaxAngularVelocity = 3636,
         MinFrictionMass = 10,
         MaxFrictionMass = 2500


### PR DESCRIPTION
Changing the default value, since it is being modified in all cases [here](https://github.com/StyledStrike/gmod-glide/blob/main/lua/glide/server/util.lua#L11-L13).

I think it is better to combine the two hooks into one, given that we are retrieving the value that has already been called.