### PR TITLE
Init vehicle no tick (Client)

### DIFF
--- a/lua/glide/client/events.lua
+++ b/lua/glide/client/events.lua
@@ -66,7 +66,7 @@ local function BlockBinds( _, bind, _, code )
 end
 
 local ScrW, ScrH = ScrW, ScrH
-local activeVehicle, activeSeatIndex = NULL, 0
+local activeVehicle = NULL
 local cvarDrawHud = GetConVar( "cl_drawhud" )
 
 local function DrawVehicleHUD()
@@ -85,7 +85,6 @@ function Glide.OnEnter( vehicle, seatIndex )
     vehicle.headlightState = 0
 
     activeVehicle = vehicle
-    activeSeatIndex = seatIndex
 
     Glide.currentVehicle = vehicle
     Glide.currentSeatIndex = seatIndex
@@ -121,7 +120,6 @@ function Glide.OnLeave( ply )
     end
 
     activeVehicle = nil
-    activeSeatIndex = 0
 
     Glide.currentVehicle = nil
     Glide.currentSeatIndex = nil

--- a/lua/glide/client/events.lua
+++ b/lua/glide/client/events.lua
@@ -79,7 +79,7 @@ local function DrawVehicleHUD()
     end
 end
 
-local function OnEnter( vehicle, seatIndex )
+function Glide.OnEnter( vehicle, seatIndex )
     vehicle:OnLocalPlayerEnter( seatIndex )
     vehicle.isLocalPlayerInVehicle = true
     vehicle.headlightState = 0
@@ -113,7 +113,7 @@ local function OnEnter( vehicle, seatIndex )
     end
 end
 
-local function OnLeave( ply )
+function Glide.OnLeave( ply )
     if IsValid( activeVehicle ) then
         activeVehicle:OnLocalPlayerExit()
         activeVehicle.isLocalPlayerInVehicle = false
@@ -145,45 +145,3 @@ local function OnLeave( ply )
     timer.Remove( "Glide.CheckMouseVisibility" )
     cvarIsMouseVisible:SetInt( 0 )
 end
-
-local IsValid = IsValid
-local LocalPlayer = LocalPlayer
-
-hook.Add( "Tick", "Glide.CheckCurrentVehicle", function()
-    local ply = LocalPlayer()
-    if not IsValid( ply ) then return end
-
-    local seat = ply:GetVehicle()
-
-    if not IsValid( seat ) then
-        if activeSeatIndex > 0 then
-            OnLeave( ply )
-        end
-
-        return
-    end
-
-    local parent = seat:GetParent()
-
-    if not IsValid( parent ) or not parent.IsGlideVehicle then
-        if activeSeatIndex > 0 then
-            OnLeave( ply )
-        end
-
-        return
-    end
-
-    local seatIndex = ply:GlideGetSeatIndex()
-
-    if activeSeatIndex ~= seatIndex then
-        if activeSeatIndex > 0 then
-            OnLeave( ply )
-        end
-
-        activeSeatIndex = seatIndex
-
-        if seatIndex > 0 then
-            OnEnter( parent, seatIndex )
-        end
-    end
-end )

--- a/lua/glide/client/events.lua
+++ b/lua/glide/client/events.lua
@@ -85,10 +85,10 @@ local tHooks = {
 }
 
 local isfunction = isfunction
-
 local sndFixed = GetConVar( "snd_fixed_rate" )
 local bSetSNDFixed = false
 local vguiCursorVisible = vgui.CursorVisible
+
 function Glide.OnEnter( vehicle, seatIndex )
     vehicle:OnLocalPlayerEnter( seatIndex )
     vehicle.isLocalPlayerInVehicle = true

--- a/lua/glide/client/events.lua
+++ b/lua/glide/client/events.lua
@@ -79,6 +79,9 @@ local function DrawVehicleHUD()
     end
 end
 
+local sndFixed = GetConVar( "snd_fixed_rate" )
+local bSetSNDFixed = false
+local vguiCursorVisible = vgui.CursorVisible
 function Glide.OnEnter( vehicle, seatIndex )
     vehicle:OnLocalPlayerEnter( seatIndex )
     vehicle.isLocalPlayerInVehicle = true
@@ -95,12 +98,13 @@ function Glide.OnEnter( vehicle, seatIndex )
     hook.Run( "Glide_OnLocalEnterVehicle", vehicle, seatIndex )
 
     timer.Create( "Glide.CheckMouseVisibility", 0.25, 0, function()
-        cvarIsMouseVisible:SetInt( vgui.CursorVisible() and 1 or 0 )
+        cvarIsMouseVisible:SetInt( vguiCursorVisible() and 1 or 0 )
     end )
 
-    if vehicle.VehicleType == Glide.VEHICLE_TYPE.HELICOPTER and system.IsLinux() then
+    if vehicle.VehicleType == Glide.VEHICLE_TYPE.HELICOPTER and system.IsLinux() and sndFixed:GetInt() ~= 1 then
         Glide.Print( "Linux system detected, setting snd_fixed_rate to 1" )
         RunConsoleCommand( "snd_fixed_rate", "1" )
+        bSetSNDFixed = true
     end
 
     -- Simple ThirdPerson compatibility
@@ -130,9 +134,10 @@ function Glide.OnLeave( ply )
     hook.Remove( "HUDPaint", "Glide.DrawVehicleHUD" )
     hook.Run( "Glide_OnLocalExitVehicle" )
 
-    if system.IsLinux() then
+    if system.IsLinux() and sndFixed:GetInt() == 1 and bSetSNDFixed then
         Glide.Print( "Linux system detected, setting snd_fixed_rate to 0" )
         RunConsoleCommand( "snd_fixed_rate", "0" )
+        bSetSNDFixed = false
     end
 
     -- Simple ThirdPerson compatibility

--- a/lua/glide/client/network.lua
+++ b/lua/glide/client/network.lua
@@ -66,6 +66,21 @@ commands[Glide.CMD_FORCE_THIRDPERSON] = function()
     Glide.Camera:SetFirstPerson( not useThirdPerson )
 end
 
+commands[Glide.CMD_ENTER_VEHICLE] = function()
+    local vehicle = net.ReadEntity()
+    if not IsValid( vehicle ) then return end
+    local iSeatIndex = net.ReadUInt( 5 )
+
+    Glide.OnEnter( vehicle, iSeatIndex )
+end
+
+commands[Glide.CMD_EXIT_VEHICLE] = function()
+    local ply = LocalPlayer()
+    if not IsValid( ply ) then return end
+
+    Glide.OnLeave( ply )
+end
+
 net.Receive( "glide.command", function()
     local cmd = net.ReadUInt( Glide.CMD_SIZE )
 

--- a/lua/glide/server/events.lua
+++ b/lua/glide/server/events.lua
@@ -105,7 +105,6 @@ hook.Add( "PlayerLeaveVehicle", "Glide.OnExitSeat", function( ply, seat )
     Glide.StartCommand( Glide.CMD_EXIT_VEHICLE )
     net.Send( ply )
 
-    print("CMD_EXIT_VEHICLE sent for player: " .. ply:Nick() .. ", seatIndex: " .. seatIndex)
 end )
 
 hook.Add( "AcceptInput", "Glide.VehicleAcceptLockInputs", function( ent, inputName )

--- a/lua/glide/server/events.lua
+++ b/lua/glide/server/events.lua
@@ -56,6 +56,11 @@ hook.Add( "PlayerEnteredVehicle", "Glide.OnEnterSeat", function( ply, seat )
     Glide.ActivateInput( ply, parent, seatIndex )
 
     hook.Run( "Glide_OnEnterVehicle", ply, parent, seatIndex )
+
+    Glide.StartCommand( Glide.CMD_ENTER_VEHICLE )
+        net.WriteEntity( parent )
+        net.WriteUInt( seatIndex, 5 )
+    net.Send( ply )
 end )
 
 -- Once a player leaves a Glide vehicle, cleanup network variables
@@ -96,6 +101,11 @@ hook.Add( "PlayerLeaveVehicle", "Glide.OnExitSeat", function( ply, seat )
     end
 
     hook.Run( "Glide_OnExitVehicle", ply, vehicle )
+
+    Glide.StartCommand( Glide.CMD_EXIT_VEHICLE )
+    net.Send( ply )
+
+    print("CMD_EXIT_VEHICLE sent for player: " .. ply:Nick() .. ", seatIndex: " .. seatIndex)
 end )
 
 hook.Add( "AcceptInput", "Glide.VehicleAcceptLockInputs", function( ent, inputName )

--- a/lua/glide/sh_network.lua
+++ b/lua/glide/sh_network.lua
@@ -7,9 +7,9 @@ end
 Glide.MAX_JSON_SIZE = 3072 -- 3 kibibytes
 
 -- Used on net.WriteUInt for the command ID
-Glide.CMD_SIZE = 4
+Glide.CMD_SIZE = 5
 
--- Command IDs (Max. ID when CMD_SIZE == 4 is 15)
+-- Command IDs (Max. ID when CMD_SIZE == 5 is 31)
 Glide.CMD_INPUT_SETTINGS = 0
 Glide.CMD_CREATE_EXPLOSION = 1
 Glide.CMD_SWITCH_SEATS = 2
@@ -25,6 +25,8 @@ Glide.CMD_UPLOAD_MISC_SOUNDS_PRESET = 11
 Glide.CMD_RELOAD_VSWEP = 13
 Glide.CMD_IS_USING_CAM_CONTROLLER = 14
 Glide.CMD_FORCE_THIRDPERSON = 15
+Glide.CMD_ENTER_VEHICLE = 16
+Glide.CMD_EXIT_VEHICLE = 17
 
 function Glide.StartCommand( id, unreliable )
     net.Start( "glide.command", unreliable or false )


### PR DESCRIPTION
Comprehensive optimization of the initialization system for when the player enters and exits the vehicle; this now operates via a network-based system.

I also decided to transmit the vehicle over the network to ensure its arrival, rather than relying on `GetVehicle` followed by `GetParent()`.

I preferred keeping it in `events` and making the functions global, since it involves a lot of hooks. If you want to make it local, I would move it to `network`.


