### PR TITLE
Glide wheels __index calls optimizations

### DIFF
--- a/lua/entities/base_glide/sv_wheels.lua
+++ b/lua/entities/base_glide/sv_wheels.lua
@@ -106,7 +106,7 @@ function ENT:PhysicsSimulate( phys, dt )
         local vehAngVel = phys:GetAngleVelocity()
 
         for _, w in EntityPairs( selfTbl.wheels ) do
-            w:DoPhysics( self, phys, traceFilter, linForce, angForce, dt, surfaceGrip, surfaceResistance, vehPos, vehVel, vehAngVel )
+            w:DoPhysics( self, phys, traceFilter, linForce, angForce, dt, surfaceGrip, surfaceResistance, vehPos, vehVel, vehAngVel, selfTbl )
 
             if w.state.isOnGround then
                 groundedCount = groundedCount + 1

--- a/lua/entities/glide_wheel/cl_init.lua
+++ b/lua/entities/glide_wheel/cl_init.lua
@@ -36,30 +36,30 @@ local IsString = isstring
 local Clamp = math.Clamp
 local GetVolume = Glide.Config.GetVolume
 
-function ENT:ProcessSound( vehicle, id, surfaceId, soundSet, altSurface, volume, pitch )
-    if not self:GetSoundsEnabled() then return end
+function ENT:ProcessSound( vehicle, id, surfaceId, soundSet, altSurface, volume, pitch, selfTbl, vehicleTbl )
+    if not selfTbl.GetSoundsEnabled( self ) then return end
 
     local path = IsString( soundSet ) and soundSet or (
-        vehicle:OverrideWheelSound( id, surfaceId ) or soundSet[surfaceId] )
-    local snd = self.sounds[id]
+        vehicleTbl:OverrideWheelSound( vehicle, id, surfaceId ) or soundSet[surfaceId] )
+    local snd = selfTbl.sounds[id]
 
     -- Remove the sound if we're on the air, or the volume is too low,
     -- or we are missing a sound path/alternative sound path for this surface.
     if surfaceId == 0 or volume < 0.01 or ( not path and not altSurface ) then
         if snd then
             snd:Stop()
-            self.sounds[id] = nil
+            selfTbl.sounds[id] = nil
         end
 
         return
     end
 
     -- Remove the sound if the surface has changed since the last call
-    if surfaceId ~= self.soundSurface[id] then
-        self.soundSurface[id] = surfaceId
+    if surfaceId ~= selfTbl.soundSurface[id] then
+        selfTbl.soundSurface[id] = surfaceId
 
         if snd then
-            self.sounds[id] = nil
+            selfTbl.sounds[id] = nil
             snd:Stop()
             snd = nil
         end
@@ -69,11 +69,11 @@ function ENT:ProcessSound( vehicle, id, surfaceId, soundSet, altSurface, volume,
         snd = CreateSound( self, path or soundSet[altSurface] )
         snd:SetSoundLevel( 80 )
         snd:PlayEx( 0, 100 )
-        self.sounds[id] = snd
+        selfTbl.sounds[id] = snd
     end
 
     snd:ChangeVolume( volume )
-    snd:ChangePitch( pitch * self.soundPitchMult )
+    snd:ChangePitch( pitch * selfTbl.soundPitchMult )
 end
 
 local WHEEL_SOUNDS = Glide.WHEEL_SOUNDS
@@ -114,21 +114,23 @@ function ENT:Think()
 
     -- Periodically rotate and resize the wheel model
     if t > selfTbl.modelCD then
-        m:SetTranslation( self:GetModelOffset() )
-        m:SetAngles( self:GetModelAngle() )
-        m:SetScale( self:GetModelScale2() )
+        m:SetTranslation( selfTbl.GetModelOffset( self ) )
+        m:SetAngles( selfTbl.GetModelAngle( self ) )
+        m:SetScale( selfTbl.GetModelScale2( self ) )
         self:EnableMatrix( "RenderMultiply", m )
         selfTbl.modelCD = t + 1
     end
 
     local parent = self:GetParent()
     if not IsValid( parent ) then return true end
-    if not parent.rfMisc then return true end
+
+    local parentTbl = getTable( parent )
+    if not parentTbl.rfMisc then return true end
 
     -- Stop processing when the "rfMisc" RangedFeature
     -- from our parent vehicle is not active.
     -- (When the player is too far away or out of the PVS).
-    local isActive = parent.rfMisc.isActive
+    local isActive = parentTbl.rfMisc.isActive
     if not isActive then return true end
 
     local velocity = parent:GetVelocity()
@@ -136,52 +138,52 @@ function ENT:Think()
     local baseVolume = GetVolume( "carVolume" )
 
     local up = parent:GetUp()
-    local surfaceId = self:GetContactSurface()
-    local contactPos = self:GetPos() - up * self:GetRadius()
+    local surfaceId = selfTbl.GetContactSurface( self )
+    local contactPos = self:GetPos() - up * selfTbl.GetRadius( self )
 
-    -- Force water surface when contactPos is under water 
+    -- Force water surface when contactPos is under water
     if surfaceId > 0 and IsUnderWater( contactPos ) then
         surfaceId = MAT_SLOSH
     end
 
     -- Mute concrete sounds when this wheel is part of a tank
-    local muteRollSound = surfaceId == 67 and parent.VehicleType == 5
+    local muteRollSound = surfaceId == 67 and parentTbl.VehicleType == 5
 
     -- Disable some effects when a blown tire is touching a "hard" surface
-    local isBlownOnHardSurface = self:IsBlown() and HARD_SURFACES[surfaceId]
+    local isBlownOnHardSurface = selfTbl.IsBlown( self ) and HARD_SURFACES[surfaceId]
 
     -- Fast roll sound
     local fastFactor = speed / 600
 
-    self:ProcessSound( parent, "fastRoll", surfaceId, WHEEL_SOUNDS.ROLL, nil,
-        Clamp( fastFactor * 0.75, 0, ROLL_VOLUME[surfaceId] or 0.4 ) * baseVolume, 70 + 25 * fastFactor )
+    selfTbl.ProcessSound( self, parent, "fastRoll", surfaceId, WHEEL_SOUNDS.ROLL, nil,
+        Clamp( fastFactor * 0.75, 0, ROLL_VOLUME[surfaceId] or 0.4 ) * baseVolume, 70 + 25 * fastFactor, selfTbl, parentTbl )
 
     -- Slow roll sound
     local slowFactor = ( isBlownOnHardSurface or muteRollSound ) and 0 or 1.02 - fastFactor
 
-    self:ProcessSound( parent, "slowRoll", surfaceId, WHEEL_SOUNDS.ROLL_SLOW, 88,
-        slowFactor * fastFactor * 2 * baseVolume, 110 - 30 * slowFactor )
+    selfTbl.ProcessSound( self, parent, "slowRoll", surfaceId, WHEEL_SOUNDS.ROLL_SLOW, 88,
+        slowFactor * fastFactor * 2 * baseVolume, 110 - 30 * slowFactor, selfTbl, parentTbl )
 
     -- Side slip sound
-    local sideSlipFactor = muteRollSound and 0 or Abs( self:GetSideSlip() ) - 0.1
+    local sideSlipFactor = muteRollSound and 0 or Abs( selfTbl.GetSideSlip( self ) ) - 0.1
 
     sideSlipFactor = Clamp( sideSlipFactor * 1.5, 0, 0.8 )
 
-    self:ProcessSound( parent, "sideSlip", surfaceId, WHEEL_SOUNDS.SIDE_SLIP, nil,
-        ( isBlownOnHardSurface and 0 or sideSlipFactor ) * baseVolume, 110 - 30 * sideSlipFactor )
+    selfTbl.ProcessSound( self, parent, "sideSlip", surfaceId, WHEEL_SOUNDS.SIDE_SLIP, nil,
+        ( isBlownOnHardSurface and 0 or sideSlipFactor ) * baseVolume, 110 - 30 * sideSlipFactor, selfTbl, parentTbl )
 
     -- Forward slip sound
-    local forwardSlip = self:GetForwardSlip() * 0.04
+    local forwardSlip = selfTbl.GetForwardSlip( self ) * 0.04
     local forwardSlipFactor = Clamp( Abs( forwardSlip ) - 0.1, 0, 1 )
 
-    self:ProcessSound( parent, "forwardSlip", surfaceId, WHEEL_SOUNDS.FORWARD_SLIP, 88,
-        ( isBlownOnHardSurface and 0 or forwardSlipFactor )  * baseVolume, 100 - forwardSlipFactor * 10 )
+    selfTbl.ProcessSound( self, parent, "forwardSlip", surfaceId, WHEEL_SOUNDS.FORWARD_SLIP, 88,
+        ( isBlownOnHardSurface and 0 or forwardSlipFactor )  * baseVolume, 100 - forwardSlipFactor * 10, selfTbl, parentTbl )
 
     -- Blown tire/rim sound
     local blownTire = isBlownOnHardSurface and Clamp( sideSlipFactor + forwardSlipFactor + ( speed / 1000 ), 0, 1 ) or 0
 
-    self:ProcessSound( parent, "blownTire", surfaceId, "glide/wheels/blowout_wheel_rim.wav", 88,
-        blownTire * 0.8 * baseVolume, 80 + blownTire * 30 )
+    selfTbl.ProcessSound( self, parent, "blownTire", surfaceId, "glide/wheels/blowout_wheel_rim.wav", 88,
+        blownTire * 0.8 * baseVolume, 80 + blownTire * 30, selfTbl, parentTbl )
 
     if muteRollSound then
         selfTbl.lastSkidId = nil
@@ -210,7 +212,7 @@ function ENT:Think()
     if isBlownOnHardSurface then return end
 
     -- Emit side slip/tire roll particles
-    local particleSize = Clamp( self:GetRadius(), 5, 10 )
+    local particleSize = Clamp( selfTbl.GetRadius( self ), 5, 10 )
     local rollFactor = sideSlipFactor - 0.5
 
     if ROLL_MARK_SURFACES[surfaceId] or surfaceId == MAT_SLOSH then
@@ -250,7 +252,7 @@ function ENT:Think()
     if not selfTbl.enableSkidmarks then return true end
 
     -- Create skidmarks
-    local skidmarkSize = self:GetRadius() * parent.WheelSkidmarkScale
+    local skidmarkSize = selfTbl.GetRadius( self ) * parentTbl.WheelSkidmarkScale
 
     contactPos = contactPos + velocity * 0.04
 

--- a/lua/entities/glide_wheel/init.lua
+++ b/lua/entities/glide_wheel/init.lua
@@ -226,12 +226,15 @@ do
     end
 end
 
+local GetTable = FindMetaTable( "Entity" ).GetTable
+
 do
     local Deg = math.deg
     local Approach = math.Approach
 
     function ENT:Update( vehicle, steerAngle, isAsleep, dt )
-        local state, params = self.state, self.params
+        local selfTbl = GetTable( self )
+        local state, params = selfTbl.state, selfTbl.params
 
         -- Get the wheel rotation relative to the vehicle, while applying the steering angle
         local ang = vehicle:LocalToWorldAngles( steerAngle * params.steerMultiplier )
@@ -244,15 +247,15 @@ do
 
         -- Do suspsension sounds
         local fraction = state.fraction
-        self:DoSuspensionSounds( fraction - state.lastFraction, vehicle )
+        selfTbl.DoSuspensionSounds( self, fraction - state.lastFraction, vehicle, selfTbl )
         state.lastFraction = fraction
 
         -- Set NW variables
         if isAsleep then
-            self:SetContactSurface( 0 )
+            selfTbl.SetContactSurface( self, 0 )
         else
-            self:SetLastSpin( state.spin )
-            self:SetContactSurface( state.lastSurfaceId )
+            selfTbl.SetLastSpin( self, state.spin )
+            selfTbl.SetContactSurface( self, state.lastSurfaceId )
         end
 
         if isAsleep or not state.isOnGround then
@@ -262,11 +265,11 @@ do
             -- Slow down eventually
             state.angularVelocity = Approach( state.angularVelocity, 0, dt * 4 )
 
-            self:SetForwardSlip( 0 )
-            self:SetSideSlip( 0 )
+            selfTbl.SetForwardSlip( self, 0 )
+            selfTbl.SetSideSlip( self, 0 )
         else
-            self:SetForwardSlip( state.lastForwardSlip )
-            self:SetSideSlip( state.lastSideSlip )
+            selfTbl.SetForwardSlip( self, state.lastForwardSlip )
+            selfTbl.SetSideSlip( self, state.lastSideSlip )
         end
 
         -- Run touch events on entities our trace hits
@@ -274,30 +277,43 @@ do
         ent = ( ent and ent.IsValid and ent:IsValid() ) and ent or nil
 
         if ent ~= state.lastTouchedEnt then
-            if state.lastTouchedEnt and state.lastTouchedEnt.EndTouch then
-                state.lastTouchedEnt:EndTouch( self )
+            if state.lastTouchedEnt then
+                local endTouch = state.lastTouchedEnt.EndTouch
+
+                if endTouch then
+                    endTouch( state.lastTouchedEnt, self )
+                end
             end
 
-            if ent and ent.StartTouch then
-                ent:StartTouch( self )
+            if ent then
+                local startTouch = ent.StartTouch
+
+                if startTouch then
+                    startTouch( ent, self )
+                end
             end
 
             state.lastTouchedEnt = ent
         end
 
-        if ent and ent.Touch then
-            ent:Touch( self )
+        if ent then
+            local touch = ent.Touch
+
+            if touch then
+                touch( ent, self )
+            end
         end
     end
 
     local TAU = math.pi * 2
+    local RAD_TO_RPM = 60 / TAU
 
     function ENT:GetRPM()
-        return self.state.angularVelocity * 60 / TAU
+        return self.state.angularVelocity * RAD_TO_RPM
     end
 
     function ENT:SetRPM( rpm )
-        self.state.angularVelocity = rpm / ( 60 / TAU )
+        self.state.angularVelocity = rpm / RAD_TO_RPM
     end
 end
 
@@ -308,20 +324,20 @@ do
     local CurTime = CurTime
     local PlaySoundSet = Glide.PlaySoundSet
 
-    function ENT:DoSuspensionSounds( change, vehicle )
-        if not self:GetSoundsEnabled() then return end
+    function ENT:DoSuspensionSounds( change, vehicle, selfTbl )
+        if not selfTbl.GetSoundsEnabled( self ) then return end
 
         local t = CurTime()
 
-        if change > 0.01 and t > self.expandSoundCD then
-            self.expandSoundCD = t + 0.3
+        if change > 0.01 and t > selfTbl.expandSoundCD then
+            selfTbl.expandSoundCD = t + 0.3
             PlaySoundSet( vehicle.SuspensionUpSound, self, Clamp( Abs( change ) * 15, 0, 0.5 ) )
         end
 
-        if change < -0.01 and t > self.contractSoundCD then
+        if change < -0.01 and t > selfTbl.contractSoundCD then
             change = Abs( change )
 
-            self.contractSoundCD = t + 0.3
+            selfTbl.contractSoundCD = t + 0.3
             PlaySoundSet( change > 0.03 and vehicle.SuspensionHeavySound or vehicle.SuspensionDownSound, self, Clamp( change * 10, 0, 1 ) )
         end
     end
@@ -359,14 +375,15 @@ local EntSetLocalPos = FindMetaTable( "Entity" ).SetLocalPos
 local tractionCycle = Vector()
 local contactPos = Vector()
 
-function ENT:DoPhysics( vehicle, phys, traceFilter, outLin, outAng, dt, vehSurfaceGrip, vehSurfaceResistance, vehPos, vehVel, vehAngVel )
-    local state, params = self.state, self.params
+function ENT:DoPhysics( vehicle, phys, traceFilter, outLin, outAng, dt, vehSurfaceGrip, vehSurfaceResistance, vehPos, vehVel, vehAngVel, vehTbl )
+    local selfTbl = GetTable( self )
+    local state, params = selfTbl.state, selfTbl.params
 
     -- Get the starting point of the raycast, where the suspension connects to the chassis
     local pos = PhysLocalToWorld( phys, params.basePos )
 
     -- Get the wheel rotation relative to the chassis, applying the steering angle if necessary
-    local ang = EntLocalToWorldAngles( vehicle, vehicle.steerAngle * params.steerMultiplier )
+    local ang = EntLocalToWorldAngles( vehicle, vehTbl.steerAngle * params.steerMultiplier )
 
     -- Do the raycast
     local up = AngUp( ang )
@@ -496,7 +513,7 @@ function ENT:DoPhysics( vehicle, phys, traceFilter, outLin, outAng, dt, vehSurfa
 
     -- Calculate side slip angle
     local slipAngle = ( Atan2( velR, Abs( velF ) ) / PI ) * 2
-    state.lastSideSlip = slipAngle * Clamp( vehicle.totalSpeed * 0.005, 0, 1 ) * 2
+    state.lastSideSlip = slipAngle * Clamp( vehTbl.totalSpeed * 0.005, 0, 1 ) * 2
 
     -- Sideways traction ramp
     slipAngle = Abs( slipAngle * slipAngle )


### PR DESCRIPTION
# Summary

This PR aims to primarily optimize access to `SENTs` wheel functions to reduce the number of `__index` and `:GetTable` calls for them

All `SENTs` functions are stored in the entity table, so every time a `__index` call is made, `:GetTable` is also called for any `SENTs` functions, which significantly slows things down. This PR fixes this by attempting to use the cached entity table everywhere.

This can be implemented for all parts of Glide for maximum effect, but the effect is most noticeable for wheels.

# Test setup:

5 unfrozen infernuses
Profiling tool: https://github.com/wrefgtzweve/gmod_perfutils/blob/main/lua/autorun/sh_indexcounter.lua
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/0eb0321e-43b3-469f-b3a2-b92d8037d0c6" />

# Test results:
## Before:
<details>
<summary>CL</summary>

```
326180 | lua/entities/glide_wheel/cl_init.lua:109
209440 | lua/entities/glide_wheel/cl_init.lua:39
208460 | lua/entities/base_glide/cl_lights.lua:67
134010 | lua/matproxy/sky_paint.lua:8
59940 | lua/includes/extensions/entity.lua:211
59560 | lua/entities/base_glide_car/cl_init.lua:296
37260 | lua/entities/base_glide/cl_init.lua:190
37225 | lua/entities/base_glide/cl_init.lua:280
35076 | gamemodes/base/gamemode/cl_init.lua:49
34831 | gamemodes/base/entities/entities/base_anim.lua:38
22335 | lua/entities/base_glide_car/shared.lua:197
22335 | lua/glide/client/ranged_feature.lua:64
20234 | lua/includes/modules/player_manager.lua:306
14960 | lua/entities/glide_wheel/shared.lua:31
14890 | gamemodes/base/gamemode/cl_init.lua:600
11912 | lua/matproxy/player_weapon_color.lua:13
10730 | lua/entities/base_glide/shared.lua:117
10417 | lua/glide/client/target_info.lua:67
8934 | gamemodes/base/gamemode/animations.lua:285
8620 | lua/matproxy/player_color.lua:18
7480 | lua/entities/base_glide_car/cl_init.lua:118
7445 | gamemodes/sandbox/entities/weapons/gmod_tool/stools/duplicator.lua:334
7445 | gamemodes/base/gamemode/cl_init.lua:357
7202 | gamemodes/base/entities/entities/base_anim.lua:44
7075 | lua/entities/base_glide_car/cl_init.lua:412
6471 | gamemodes/base/gamemode/cl_init.lua:555
5956 | lua/glide/sh_player.lua:4
5956 | gamemodes/base/gamemode/player_class/taunt_camera.lua:38
5956 | gamemodes/base/gamemode/animations.lua:197
5956 | gamemodes/base/gamemode/animations.lua:305
5650 | lua/includes/modules/drive.lua:56
4467 | gamemodes/base/gamemode/animations.lua:258
4467 | gamemodes/base/gamemode/cl_init.lua:418
2978 | gamemodes/base/gamemode/cl_init.lua:585
2978 | gamemodes/base/gamemode/animations.lua:71
2978 | addons/ez/lua/easychat/networking.lua:661
2802 | lua/includes/extensions/util.lua:37
2443 | gamemodes/base/gamemode/obj_player_extend.lua:173
2157 | gamemodes/sandbox/gamemode/player_class/player_sandbox.lua:130
2157 | gamemodes/base/gamemode/player_class/taunt_camera.lua:98
1998 | lua/glide/client/events.lua:160
1489 | gamemodes/base/gamemode/animations.lua:348
1489 | lua/glide/sh_anims.lua:5
1489 | lua/glide/sh_anims.lua:61
1489 | addons/ez/lua/easychat/easychat.lua:213
1489 | gamemodes/sandbox/gamemode/player_class/player_sandbox.lua:139
1489 | gamemodes/sandbox/gamemode/player_class/player_sandbox.lua:121
1489 | gamemodes/sandbox/gamemode/cl_init.lua:127
1489 | gamemodes/base/gamemode/animations.lua:129
1042 | addons/classicbox_ui-main/lua/autorun/client/cl_targetid.lua:11
744 | lua/glide/client/config.lua:1200
60 | lua/glide/client/lock_on.lua:158
```
</details>

<details>
<summary>SV</summary>

```
146520 | lua/entities/glide_wheel/init.lua:233
89910 | lua/entities/base_glide_car/init.lua:637
53280 | lua/glide/sh_utils.lua:167
53280 | lua/entities/base_glide/init.lua:643
53280 | lua/entities/glide_wheel/init.lua:362
39960 | lua/entities/base_glide_car/init.lua:358
36630 | lua/entities/base_glide/sv_wheels.lua:79
23310 | lua/entities/base_glide_car/init.lua:496
23310 | lua/entities/base_glide/sv_lights.lua:45
19980 | lua/entities/base_glide/sv_water.lua:46
13320 | lua/entities/base_glide/sv_input.lua:76
13320 | lua/entities/glide_wheel/init.lua:295
13320 | lua/entities/glide_wheel/init.lua:311
9990 | lua/entities/base_glide/sv_input.lua:46
8325 | lua/entities/base_glide_car/init.lua:540
6660 | lua/entities/base_glide/shared.lua:117
6660 | lua/entities/base_glide_car/sv_engine.lua:129
6660 | lua/entities/glide_wheel/init.lua:299
3996 | lua/glide/sh_player.lua:4
3996 | lua/includes/modules/player_manager.lua:306
3330 | lua/entities/base_glide_car/init.lua:335
3330 | lua/entities/base_glide_car/init.lua:621
3330 | lua/entities/base_glide_car/sv_engine.lua:112
2664 | gamemodes/base/gamemode/animations.lua:305
2664 | gamemodes/base/gamemode/animations.lua:197
1998 | lua/includes/modules/drive.lua:56
1998 | gamemodes/base/gamemode/animations.lua:258
1332 | gamemodes/base/gamemode/animations.lua:71
1332 | addons/ez/lua/easychat/networking.lua:661
666 | lua/glide/sh_anims.lua:5
666 | lua/glide/sh_player.lua:96
666 | gamemodes/base/gamemode/animations.lua:348
666 | addons/ez/lua/easychat/easychat.lua:213
666 | gamemodes/base/gamemode/animations.lua:129
666 | lua/glide/sh_anims.lua:61
306 | gamemodes/base/entities/entities/env_skypaint.lua:97
4 | gamemodes/base/gamemode/player.lua:754
4 | lua/includes/modules/numpad.lua:59
4 | lua/includes/modules/numpad.lua:97
3 | lua/includes/modules/numpad.lua:123
2 | lua/includes/util.lua:314
```
</details>

## After:
<details>
<summary>CL</summary>

```
208600 | addons/gmod-glide/lua/entities/base_glide/cl_lights.lua:67
134100 | lua/matproxy/sky_paint.lua:8
119560 | addons/gmod-glide/lua/entities/glide_wheel/cl_init.lua:109
59850 | lua/includes/extensions/entity.lua:211
59600 | addons/gmod-glide/lua/entities/base_glide_car/cl_init.lua:296
46190 | gamemodes/base/entities/entities/base_anim.lua:38
37490 | addons/gmod-glide/lua/entities/base_glide/cl_init.lua:190
37328 | gamemodes/base/gamemode/cl_init.lua:49
37250 | addons/gmod-glide/lua/entities/base_glide/cl_init.lua:280
22350 | addons/gmod-glide/lua/glide/client/ranged_feature.lua:64
22350 | addons/gmod-glide/lua/entities/base_glide_car/shared.lua:197
20244 | lua/includes/modules/player_manager.lua:306
14920 | addons/gmod-glide/lua/entities/glide_wheel/shared.lua:31
14900 | gamemodes/base/gamemode/cl_init.lua:600
11920 | lua/matproxy/player_weapon_color.lua:13
10625 | addons/gmod-glide/lua/entities/base_glide/shared.lua:117
8940 | gamemodes/base/entities/entities/base_anim.lua:44
8940 | gamemodes/base/gamemode/animations.lua:285
8620 | lua/matproxy/player_color.lua:18
7480 | addons/gmod-glide/lua/entities/base_glide_car/cl_init.lua:118
7450 | gamemodes/base/gamemode/cl_init.lua:357
7450 | gamemodes/sandbox/entities/weapons/gmod_tool/stools/duplicator.lua:334
6525 | addons/gmod-glide/lua/entities/base_glide_car/cl_init.lua:412
6474 | gamemodes/base/gamemode/cl_init.lua:555
5960 | gamemodes/base/gamemode/animations.lua:197
5960 | gamemodes/base/gamemode/player_class/taunt_camera.lua:38
5960 | gamemodes/base/gamemode/animations.lua:305
5960 | addons/gmod-glide/lua/glide/sh_player.lua:4
5652 | lua/includes/modules/drive.lua:56
4470 | gamemodes/base/gamemode/cl_init.lua:418
4470 | gamemodes/base/gamemode/animations.lua:258
3888 | addons/classicbox_ui-main/lua/autorun/client/cl_targetid.lua:11
2980 | gamemodes/base/gamemode/animations.lua:71
2980 | addons/ez/lua/easychat/networking.lua:661
2980 | gamemodes/base/gamemode/cl_init.lua:585
2592 | lua/includes/extensions/util.lua:37
2592 | addons/gmod-glide/lua/glide/client/target_info.lua:67
2158 | gamemodes/base/gamemode/player_class/taunt_camera.lua:98
2158 | gamemodes/sandbox/gamemode/player_class/player_sandbox.lua:130
1995 | addons/gmod-glide/lua/glide/client/events.lua:160
1490 | addons/gmod-glide/lua/glide/sh_anims.lua:5
1490 | gamemodes/sandbox/gamemode/player_class/player_sandbox.lua:121
1490 | gamemodes/sandbox/gamemode/cl_init.lua:127
1490 | gamemodes/sandbox/gamemode/player_class/player_sandbox.lua:139
1490 | gamemodes/base/gamemode/animations.lua:348
1490 | gamemodes/base/gamemode/animations.lua:129
1490 | addons/gmod-glide/lua/glide/sh_anims.lua:61
1490 | addons/ez/lua/easychat/easychat.lua:213
1296 | gamemodes/base/gamemode/obj_player_extend.lua:173
745 | addons/gmod-glide/lua/glide/client/config.lua:1200
60 | addons/gmod-glide/lua/glide/client/lock_on.lua:158
```
</details>

<details>
<summary>SV</summary>

```
89910 | addons/gmod-glide/lua/entities/base_glide_car/init.lua:637
53280 | addons/gmod-glide/lua/entities/base_glide/init.lua:643
53280 | addons/gmod-glide/lua/glide/sh_utils.lua:167
53280 | addons/gmod-glide/lua/entities/glide_wheel/init.lua:235
39960 | addons/gmod-glide/lua/entities/base_glide_car/init.lua:358
36630 | addons/gmod-glide/lua/entities/base_glide/sv_wheels.lua:79
23310 | addons/gmod-glide/lua/entities/base_glide_car/init.lua:496
23310 | addons/gmod-glide/lua/entities/base_glide/sv_lights.lua:45
19980 | addons/gmod-glide/lua/entities/base_glide/sv_water.lua:46
13320 | addons/gmod-glide/lua/entities/base_glide/sv_input.lua:76
13320 | addons/gmod-glide/lua/entities/glide_wheel/init.lua:311
9990 | addons/gmod-glide/lua/entities/base_glide/sv_input.lua:46
8325 | addons/gmod-glide/lua/entities/base_glide_car/init.lua:540
6660 | addons/gmod-glide/lua/entities/base_glide_car/sv_engine.lua:129
6660 | addons/gmod-glide/lua/entities/glide_wheel/init.lua:315
6660 | addons/gmod-glide/lua/entities/base_glide/shared.lua:117
3996 | lua/includes/modules/player_manager.lua:306
3996 | addons/gmod-glide/lua/glide/sh_player.lua:4
3330 | addons/gmod-glide/lua/entities/base_glide_car/init.lua:335
3330 | addons/gmod-glide/lua/entities/base_glide_car/init.lua:621
3330 | addons/gmod-glide/lua/entities/base_glide_car/sv_engine.lua:112
2664 | gamemodes/base/gamemode/animations.lua:197
2664 | gamemodes/base/gamemode/animations.lua:305
1998 | lua/includes/modules/drive.lua:56
1998 | gamemodes/base/gamemode/animations.lua:258
1332 | addons/ez/lua/easychat/networking.lua:661
1332 | gamemodes/base/gamemode/animations.lua:71
666 | addons/gmod-glide/lua/glide/sh_anims.lua:61
666 | addons/gmod-glide/lua/glide/sh_anims.lua:5
666 | addons/gmod-glide/lua/glide/sh_player.lua:96
666 | gamemodes/base/gamemode/animations.lua:348
666 | addons/ez/lua/easychat/easychat.lua:213
666 | gamemodes/base/gamemode/animations.lua:129
312 | gamemodes/base/entities/entities/env_skypaint.lua:97
4 | gamemodes/base/gamemode/player.lua:754
2 | lua/includes/util.lua:314
```
</details>

About x4 less `__index` calls on both server and client