### PR TITLE
Guard the debug overlay against an invalid physics object

### DIFF
--- a/lua/entities/base_glide/init.lua
+++ b/lua/entities/base_glide/init.lua
@@ -789,7 +789,7 @@ function ENT:Think()
     end
 
     -- Draw debug overlays, if `developer` cvar is active
-    if GetDevMode() then
+    if GetDevMode() and IsValid( phys ) then
         debugoverlay.Axis( self:LocalToWorld( phys:GetMassCenter() ), self:GetAngles(), 15, 0.1, true )
     end
 


### PR DESCRIPTION
Hello — first contribution here, starting with something small.

`ENT:Think` in `base_glide/init.lua` fetches the physics object and guards every use of it behind `if IsValid( phys )`. The debug overlay sits after that block has closed and dereferences it anyway:

```lua
if GetDevMode() then
    debugoverlay.Axis( self:LocalToWorld( phys:GetMassCenter() ), self:GetAngles(), 15, 0.1, true )
end
```

A vehicle whose physics object is invalid — during removal, or after a failed `PhysicsInit` — raises a Lua error every tick while `developer` is set.

It only fires with `developer 1`, which is probably why it has gone unnoticed: an extra error in the console is least visible exactly when everything else is being printed too.

The change adds the guard the surrounding code already applies. No behaviour change when the physics object is valid, which is every normal case.

No known issues with the patch.