### PR TITLE
Fix two latent defects in the ragdoll disabler tool

### DIFF
--- a/lua/weapons/gmod_tool/stools/glide_ragdoll_disabler.lua
+++ b/lua/weapons/gmod_tool/stools/glide_ragdoll_disabler.lua
@@ -28,7 +28,7 @@ if SERVER then
 
         duplicator.ClearEntityModifier( ent, "glide_ragdoll_disabler" )
 
-        local enableFall = type( data == "table" ) and data.enableFall == true
+        local enableFall = type( data ) == "table" and data.enableFall == true
         ent.FallOnCollision = enableFall
         ent.FallWhileUnderWater = enableFall
 
@@ -61,6 +61,9 @@ function TOOL:RightClick( trace )
     if not veh then return false end
 
     if SERVER then
+        local owner = self:GetOwner()
+        if not IsValid( owner ) then return end
+
         ApplyRagdollDisabler( owner, veh, { enableFall = true } )
     end
 


### PR DESCRIPTION
Two defects in `glide_ragdoll_disabler.lua`. Neither fires on the happy path today, which is why both have survived — each is a trap for whoever next changes the surrounding code.

### 1. A type guard that never guards

```lua
local enableFall = type( data == "table" ) and data.enableFall == true
```

The parenthesis is misplaced. This evaluates `data == "table"`, which is `false` for any table, then `type( false )` — the string `"boolean"`, which is truthy. The guard is therefore always satisfied, and `data.enableFall` raises on anything that is not a table.

It is reached from `duplicator.RegisterEntityModifier`, so the argument comes from saved dupe data rather than from the tool itself.

### 2. A bare global where a local was intended

`TOOL:LeftClick` declares its owner and checks it:

```lua
local owner = self:GetOwner()
if not IsValid( owner ) then return end
```

`TOOL:RightClick` does neither, and passes a bare `owner` — the global, which is `nil`. Harmless while `ApplyRagdollDisabler` ignores its first parameter, and a silent `nil` the day it does not.

The patch mirrors `LeftClick` exactly, including its bare `return`, rather than inventing a different convention.

No known issues with the patch.