### PR TITLE
Take the wheel physics off the PhysObj interface where the entity can answer

### DIFF
--- a/lua/entities/base_glide/sv_wheels.lua
+++ b/lua/entities/base_glide/sv_wheels.lua
@@ -73,6 +73,7 @@ local VectorSetUnpacked = FindMetaTable( "Vector" ).SetUnpacked
 
 local Abs = math.abs
 local Clamp = math.Clamp
+local Rad = math.rad
 local ClampForce = Glide.ClampForce
 
 local linForce, angForce = Vector(), Vector()
@@ -104,6 +105,19 @@ function ENT:PhysicsSimulate( phys, dt )
 
         local vehPos = phys:GetPos()
         local changedPosCount = 0
+
+        -- Derive here, once, what all four wheels would otherwise ask the physics object for
+        -- individually. See DoPhysics for why these are worth hoisting.
+        --
+        -- GetAngleVelocity is in degrees per second on the object's local axes, so it is
+        -- converted to radians and rotated into world space a single time.
+        local angVel = phys:GetAngleVelocity()
+        local worldAngVel = Vector( Rad( angVel[1] ), Rad( angVel[2] ), Rad( angVel[3] ) )
+        worldAngVel:Rotate( self:GetAngles() )
+
+        selfTbl.wheelAngularVelocity = worldAngVel
+        selfTbl.wheelMassCenter = self:LocalToWorld( phys:GetMassCenter() )
+        selfTbl.wheelVelocity = self:GetVelocity()
 
         for _, w in EntityPairs( selfTbl.wheels ) do
             local wheelTbl = GetTable( w )

--- a/lua/entities/glide_wheel/init.lua
+++ b/lua/entities/glide_wheel/init.lua
@@ -362,13 +362,23 @@ local VectorDot = FindMetaTable( "Vector" ).Dot
 local AngForward = FindMetaTable( "Angle" ).Forward
 local AngUp = FindMetaTable( "Angle" ).Up
 
-local PhysWorldToLocal = FindMetaTable( "PhysObj" ).WorldToLocal
-local PhysLocalToWorld = FindMetaTable( "PhysObj" ).LocalToWorld
-local PhysGetVelocityAtPoint = FindMetaTable( "PhysObj" ).GetVelocityAtPoint
+-- CalculateForceOffset is the only PhysObj call left in this path. The other three go through
+-- their entity-side equivalent, which is around four hundred times cheaper. The equivalences
+-- were measured on a live vehicle at arbitrary angles:
+--
+--   phys:LocalToWorld( v )        == ent:LocalToWorld( v )                deviation 0.00098
+--   phys:WorldToLocal( p )        == ent:WorldToLocal( p )                deviation 0.00098
+--   phys:GetVelocityAtPoint( p )  == velocity + angVel x (p - masscentre) deviation 0.00016
+--
+-- The first two need no mass-centre offset: the physics object's local frame coincides with
+-- the entity's.
 local PhysCalculateForceOffset = FindMetaTable( "PhysObj" ).CalculateForceOffset
 
 local EntLocalToWorldAngles = FindMetaTable( "Entity" ).LocalToWorldAngles
 local EntSetLocalPos = FindMetaTable( "Entity" ).SetLocalPos
+local EntLocalToWorld = FindMetaTable( "Entity" ).LocalToWorld
+local EntWorldToLocal = FindMetaTable( "Entity" ).WorldToLocal
+local VectorCross = FindMetaTable( "Vector" ).Cross
 
 --local Accelerate = GlideAccelerate
 local tractionCycle = Vector()
@@ -379,7 +389,7 @@ function ENT:DoPhysics( vehicle, phys, traceFilter, outLin, outAng, dt, vehSurfa
     local state, params = selfTbl.state, selfTbl.params
 
     -- Get the starting point of the raycast, where the suspension connects to the chassis
-    local pos = PhysLocalToWorld( phys, params.basePos )
+    local pos = EntLocalToWorld( vehicle, params.basePos )
 
     -- Get the wheel rotation relative to the chassis, applying the steering angle if necessary
     local ang = EntLocalToWorldAngles( vehicle, vehTbl.steerAngle * params.steerMultiplier )
@@ -406,7 +416,7 @@ function ENT:DoPhysics( vehicle, phys, traceFilter, outLin, outAng, dt, vehSurfa
     VectorSet( contactPos, pos )
     VectorSub( contactPos, maxLen * state.fraction * up )
 
-    EntSetLocalPos( self, PhysWorldToLocal( phys, contactPos + up * radius ) )
+    EntSetLocalPos( self, EntWorldToLocal( vehicle, contactPos + up * radius ) )
 
     -- Update ground contact NW variables
     local surfaceId = ray.Hit and ( ray.MatType or 0 ) or 0
@@ -426,8 +436,10 @@ function ENT:DoPhysics( vehicle, phys, traceFilter, outLin, outAng, dt, vehSurfa
 
     pos = contactPos
 
-    -- Get the velocity at the wheel position
-    local vel = PhysGetVelocityAtPoint( phys, pos )
+    -- Get the velocity at the wheel position, from the values PhysicsSimulate derived once
+    -- for all four wheels
+    local vel = vehTbl.wheelVelocity +
+        VectorCross( vehTbl.wheelAngularVelocity, pos - vehTbl.wheelMassCenter )
 
     -- Store some directions, perpendicular to the surface normal
     local upAlign = VectorDot( up, ray.HitNormal )


### PR DESCRIPTION
Addresses the measurements in #335, where a `PhysObj` access is shown to cost 90-175 us against 0.2 us for the entity-side call, and `DoPhysics` performs four of them per wheel per substep.

**Three of the four are replaced. The fourth is deliberately left alone.**

### The substitutions

Each was measured on a live vehicle at arbitrary angles rather than derived from the docs:

| replaced | by | deviation |
|---|---|---|
| `phys:LocalToWorld( v )` | `ent:LocalToWorld( v )` | 0.00098 |
| `phys:WorldToLocal( p )` | `ent:WorldToLocal( p )` | 0.00098 |
| `phys:GetVelocityAtPoint( p )` | `velocity + angVel x ( p - masscentre )` | 0.00016 |

There is **no mass-centre offset** to apply to the first two: the physics object local frame coincides with the entity one. That was my working assumption going in and it was wrong — applying it introduced 12 units of error everywhere.

The velocity form needs the angular velocity and the world mass centre. Both are derived **once per substep** in `PhysicsSimulate`, which already holds the physics object, and read by all four wheels. That trades sixteen accesses per vehicle per substep for one.

### What is not replaced, and why

`CalculateForceOffset` stays. It returns an impulse — the torque divided by the inertia tensor including its coupling — not a plain cross product. Measured per-component ratios of 44.8 / 30.0 / 26.5 do not follow the inertia 1882 / 1702 / 301, so it is not a component-wise division and I could not reproduce it reliably.

It is also the call that applies force to the wheels. Reconstructing it slightly wrong would change how vehicles handle with nothing visibly broken, which is not a risk worth the last quarter of the gain.

### Result

Eight vehicles, 413 frames each, same map and same player before and after, with every other local change identical in both arms:

| | before | after |
|---|---|---|
| PhysObj calls | 164.6 /frame | **80.0 /frame** |
| time in them | 18.44 ms/frame | **7.95 ms/frame** |
| `CServerGameDLL::GameFrame` | 26.01 ms/frame | **13.88 ms/frame** |

I am deliberately not quoting a fleet-wide tick rate: the figure I have for that also includes a separate change slowing `Think` for parked vehicles, and attributing it here would overstate this patch.

### Evidence that handling is unchanged

Trajectories were recorded tick by tick over a fixed 13-second input programme, three runs before and three after. The before/after deviation stays inside the same envelope as two runs of identical code — at worst 0.20 units of position over 430 ticks, with final positions agreeing to three decimals.

Bit-identical reproduction does not exist here, so "within the noise of the unmodified build" is the criterion, with the noise measured rather than assumed. It has also been driven in game.

### Known issues

The change was developed and measured in a fork of this addon; what is proposed here is a clean port of it, differing only in identifier names and comments. The measurements above come from that fork, not from this branch.