### PR TITLE
Read wheel slip from a single source

### DIFF
--- a/lua/entities/base_glide_car/init.lua
+++ b/lua/entities/base_glide_car/init.lua
@@ -655,10 +655,13 @@ function ENT:WheelThink( dt, selfTbl )
         local wheelTbl = GetTable( w )
         wheelTbl.Update( w, self, steerAngle, isAsleep, dt, wheelTbl )
 
-        totalSideSlip = totalSideSlip + wheelTbl.GetSideSlip( w )
-        totalForwardSlip = totalForwardSlip + wheelTbl.GetForwardSlip( w )
-
         state = wheelTbl.state
+
+        -- Read from the wheel rather than from its network variables: these averages steer the
+        -- car and pick its gear, so they should not depend on the presentation layer.
+        totalSideSlip = totalSideSlip + state.effectiveSideSlip
+        totalForwardSlip = totalForwardSlip + state.effectiveForwardSlip
+
         rpm = wheelTbl.GetRPM( w )
         avgRPM = avgRPM + rpm * state.distributionFactor
 

--- a/lua/entities/glide_wheel/init.lua
+++ b/lua/entities/glide_wheel/init.lua
@@ -66,7 +66,13 @@ function ENT:Initialize()
         fraction = 0,
         lastSurfaceId = 0,
         lastForwardSlip = 0,
-        lastSideSlip = 0
+        lastSideSlip = 0,
+
+        -- What the wheel actually reports: the values above, or zero while it is asleep or off
+        -- the ground. Both the network variables and the vehicle's physics read these, so the
+        -- rule that zeroes them is written once.
+        effectiveForwardSlip = 0,
+        effectiveSideSlip = 0
     }
 
     -- Used for raycasting, updates with wheel radius
@@ -264,12 +270,15 @@ do
             -- Slow down eventually
             state.angularVelocity = Approach( state.angularVelocity, 0, dt * 4 )
 
-            selfTbl.SetForwardSlip( self, 0 )
-            selfTbl.SetSideSlip( self, 0 )
+            state.effectiveForwardSlip = 0
+            state.effectiveSideSlip = 0
         else
-            selfTbl.SetForwardSlip( self, state.lastForwardSlip )
-            selfTbl.SetSideSlip( self, state.lastSideSlip )
+            state.effectiveForwardSlip = state.lastForwardSlip
+            state.effectiveSideSlip = state.lastSideSlip
         end
+
+        selfTbl.SetForwardSlip( self, state.effectiveForwardSlip )
+        selfTbl.SetSideSlip( self, state.effectiveSideSlip )
 
         -- Run touch events on entities our trace hits
         local ent = state.ray.Entity


### PR DESCRIPTION
Addresses 339 — see https://github.com/StyledStrike/gmod-glide/issues/339.

**Behaviour is identical by construction**, since the value written to the network and the value read by the physics become the same variable.

### The change

The branch in `glide_wheel/init.lua` that already decides what the wheel reports now stores its result before sending it:

```lua
if isAsleep or not state.isOnGround then
    state.effectiveForwardSlip = 0
    state.effectiveSideSlip = 0
else
    state.effectiveForwardSlip = state.lastForwardSlip
    state.effectiveSideSlip = state.lastSideSlip
end

selfTbl.SetForwardSlip( self, state.effectiveForwardSlip )
selfTbl.SetSideSlip( self, state.effectiveSideSlip )
```

`base_glide_car/init.lua` then accumulates from `state` instead of the network getters.

I went this way rather than the obvious one because reading `state.lastSideSlip` directly is **not** equivalent: the network value is forced to zero while a wheel is asleep or off the ground, and `state` keeps its last value, so a naive substitution would feed stale slip from airborne wheels into the steering. Mirroring the condition at the consumer would have worked too, but would encode the same rule in two places.

### What it buys

The averages that steer the car and shift its gears no longer travel through the presentation layer, so the wheels' network traffic can be tuned — quantised, written on change only, sent less often — without touching how the vehicle drives.

It also removes eight network variable reads per vehicle per tick, though that is incidental.

### Known issues

Touches the same file as #336, so the two will conflict textually if both are taken; they are independent in substance.