### PR TITLE
Make suspension damping independent of the tick rate

### DIFF
--- a/lua/entities/glide_wheel/init.lua
+++ b/lua/entities/glide_wheel/init.lua
@@ -350,6 +350,11 @@ local TAU = math.pi * 2
 local Min = math.min
 local Max = math.max
 local Atan2 = math.atan2
+-- Tick interval the shipped `springDamper` values were tuned against. The damping calculation
+-- below is scaled by this so that at 33 tick nothing changes, and only the dependence on the
+-- tick rate disappears. Changing it retunes every vehicle in existence.
+local DAMPER_REFERENCE_DT = 1 / 33
+
 local Approach = math.Approach
 local TraceHull = util.TraceHull
 local TractionRamp = Glide.TractionRamp
@@ -446,7 +451,11 @@ function ENT:DoPhysics( vehicle, phys, traceFilter, outLin, outAng, dt, vehSurfa
     -- Suspension spring force & damping
     local offset = maxLen - ( state.fraction * maxLen )
     local springForce = ( offset * params.springStrength )
-    local damperForce = ( state.lastSpringOffset - offset ) * params.springDamper
+    -- `lastSpringOffset - offset` is a difference of positions between two calls, not a rate,
+    -- so it needs dividing by `dt` to be a damper. Scaling back by the reference interval keeps
+    -- the force identical at 33 tick while removing the dependence.
+    local damperForce = ( ( state.lastSpringOffset - offset ) / dt ) *
+        params.springDamper * DAMPER_REFERENCE_DT
 
     state.lastSpringOffset = offset
 


### PR DESCRIPTION
Addresses https://github.com/StyledStrike/gmod-glide/issues/341.

### The change

```lua
local damperForce = ( ( state.lastSpringOffset - offset ) / dt ) *
    params.springDamper * DAMPER_REFERENCE_DT
```

with `DAMPER_REFERENCE_DT = 0.015`.

Dividing by `dt` turns the position difference into a rate, which is what a damper needs. Multiplying by the reference interval scales the result back so that **at the default tick interval the force is exactly what it is today**, and every existing `springDamper` keeps its meaning.

What disappears is the dependence: a server at half that rate now gets the same damping it gets at the default, where before it got double.

### Choosing the reference

Corrected from `1 / 33` after your comment: the default is `66.66...`, and that is what base vehicles were developed with. The earlier value was not a stylistic choice, it was wrong — it doubled the damper force at the default rate, so the patch would have retuned the whole ecosystem instead of leaving it alone, which is the exact outcome this PR exists to avoid. The constant is named rather than inlined so the decision stays visible.

### How to see it

Drive a vehicle over the same bump at the default tick rate and at half of it, and compare the rebound. Before this change they differ; after it they should not. That difference is the clearest way to see the defect itself.

### Known issues

The reference value is the documented default tick interval, not something I measured on a running server — if `PhysicsSimulate` ever receives a `dt` that is not the tick interval, the claim "unchanged at the default rate" weakens to "unchanged at whatever that dt is", though the tick-rate independence itself still holds.

I have not driven every vehicle class through this, and suspension feel is subjective — if any vehicle feels different at the default rate after this patch, that is a bug in it and I would want to know.

Touches the same file as #336 and #340, so they will conflict textually if several are taken; they are independent in substance.
