### PR TITLE
Say what the grip clamp actually computes

### DIFF
--- a/lua/entities/glide_wheel/init.lua
+++ b/lua/entities/glide_wheel/init.lua
@@ -519,8 +519,12 @@ function ENT:DoPhysics( vehicle, phys, traceFilter, outLin, outAng, dt, vehSurfa
     -- Reduce sideways traction force as the wheel slips forward
     sideForce = sideForce * ( 1 - Clamp( Abs( gripLoss ) * 0.1, 0, 1 ) * 0.9 )
 
-    -- Reduce sideways force as the suspension spring applies less force
-    surfaceGrip = surfaceGrip * Clamp( springForce / params.springStrength, 0, 1 )
+    -- Reduce sideways force as the suspension compresses less.
+    --
+    -- `springForce` is `offset * springStrength`, so dividing it by `springStrength` yields
+    -- `offset`: the spring strength cancels and this is the suspension travel clamped to one,
+    -- not a load factor. Written out so it does not read as one.
+    surfaceGrip = surfaceGrip * Clamp( offset, 0, 1 )
 
     -- Apply sideways traction force
     VectorAdd( force, Clamp( sideForce, -maxTraction, maxTraction ) * surfaceGrip * rt )


### PR DESCRIPTION
Addresses https://github.com/StyledStrike/gmod-glide/issues/343. **No behaviour change**: the two expressions are equal.

`springForce` is `offset * springStrength` (line 448), so `springForce / springStrength` is `offset`. The spring strength cancels, and what reads as normalising a force against the spring that produced it is the suspension travel clamped to one.

Whether that is the intended behaviour is a separate question — a wheel off the ground should indeed lose grip, so it may well be. This PR only makes the line say what it does, so the next person tuning grip does not spend time on the division before noticing it cancels.

Kept separate from anything that alters grip, so that if a real load sensitivity is added later the diff shows what was there before rather than mixing the two.

### Known issues

Touches the same file as #336, #340 and #342, so they will conflict textually if several are taken; they are independent in substance.