### PR TITLE
Send glide_vehicle_turret to the vehicle itself

### DIFF
--- a/lua/entities/glide_vehicle_turret/shared.lua
+++ b/lua/entities/glide_vehicle_turret/shared.lua
@@ -174,6 +174,7 @@ function ENT:FireBullet( pos, ang, attacker, shellDir )
             HullSize = 2,
             Spread = Vector(),
             IgnoreEntity = self:GetParent(),
+            Inflictor = self:GetParent(),
             TracerName = "MuzzleFlash",
             AmmoType = "SMG1"
         } )


### PR DESCRIPTION
The entity itself is currently used, which is somewhat consistent with other glide attacking stuff
Turrets typically don't have an owner, and hooks can't get useful information from them, unlike vehicle entities