### PR TITLE
Fixed an issue where the wheel radius did not always change.

### DIFF
--- a/lua/entities/glide_wheel/init.lua
+++ b/lua/entities/glide_wheel/init.lua
@@ -204,6 +204,11 @@ function ENT:ChangeRadius( radius )
     -- Used on util.TraceHull
     state.traceData.mins = Vector( radius * -0.2, radius * -0.2, 0 )
     state.traceData.maxs = Vector( radius * 0.2, radius * 0.2, radius * 0.5 )
+
+    local parent = self:GetParent()
+    if IsValid( parent ) then
+        parent:AwakePhysics()
+    end
 end
 
 do


### PR DESCRIPTION
When spawning a glide vehicle and shooting at its tires, the wheel radius sometimes fails to update. This PR ensures that the radius updates every time, rather than only intermittently.

# Without the fix
https://youtu.be/8x4v8LgT8q4

# With the fix
https://youtu.be/elc6XQl8v5w